### PR TITLE
fix no new privs flag name

### DIFF
--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -52,7 +52,7 @@ features include:
    container. This means access to files and devices from the
    container is easily controlled with standard POSIX permissions.
  - Container filesystems are mounted ``nosuid`` and container
-   applications run with the ``PR_NO_NEW_PRIVS`` flag set. This means
+   applications run with the ``no_new_privs`` bit set. This means
    that applications in a container cannot gain additional
    privileges. A regular user cannot ``sudo`` or otherwise gain root
    privilege on the host via a container.


### PR DESCRIPTION
PR_NO_NEW_PRIVS is not a flag. The flag (bit) on the process is no_new_privs and the flag passed to prctl is PR_SET_NO_NEW_PRIVS (see https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html)