### PR TITLE
Use Singularity package name consistently, from sylabs 3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update repositories
+        run: |
+          sudo apt update
+
       - name: Install LaTeX dependencies
         run: |
           sudo apt-get install -f -y texlive-latex-extra latexmk

--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -2,19 +2,19 @@
 Admin Quick Start
 =================
 
-This quick start gives an overview of installation of Singularity from
-source, a description of the architecture of Singularity, and
+This quick start gives an overview of installation of {Singularity} from
+source, a description of the architecture of {Singularity}, and
 pointers to configuration files. More information, including alternate
 installation options and detailed configuration options can be found
 later in this guide.
 
 .. _singularity-architecture:
 
----------------------------
-Architecture of Singularity
----------------------------
+-----------------------------
+Architecture of {Singularity}
+-----------------------------
 
-Singularity is designed to allow containers to be executed as if they
+{Singularity} is designed to allow containers to be executed as if they
 were native programs or scripts on a host system. No daemon is
 required to build or run containers, and the security model is compatible
 with shared systems.
@@ -26,7 +26,7 @@ IPC, and other communication pathways used by locally running programs
 are synchronized with the applications running locally within the
 container.
 
-Singularity favors an 'integration over isolation' approach to
+{Singularity} favors an 'integration over isolation' approach to
 containers. By default only the mount namespace is isolated for
 containers, so that they have their own filesystem view. Access to
 hardware such as GPUs, high speed networks, and shared filesystems is
@@ -34,17 +34,17 @@ easy and does not require special configuration. User home
 directories, ``/tmp`` space, and installation specific mounts make it
 simple for users to benefit from the reproducibility of containerized
 applications without major changs to their existing workflows. Where
-more complete isolation is important, Singularity can use additional
+more complete isolation is important, {Singularity} can use additional
 Linux namespaces and other security and resource limits to accomplish
 this.
 
 .. _singularity-security:
 
---------------------
-Singularity Security
---------------------
+----------------------
+{Singularity} Security
+----------------------
 
-Singularity uses a number of strategies to provide safety and
+{Singularity} uses a number of strategies to provide safety and
 ease-of-use on both single-user and shared systems. Notable security
 features include:
 
@@ -69,43 +69,43 @@ To support the SIF image format, automated networking setup etc., and
 older Linux distributions without user namespace support, Singularity
 runs small amounts of privileged container setup code via a
 ``starter-setuid`` binary. This is a 'setuid root' binary, so that
-Singularity can perform filesystem loop mounts and other operations
+{Singularity} can perform filesystem loop mounts and other operations
 that need privilege. The setuid flow is the default mode of operation,
 but :ref:`can be disabled <install-nonsetuid>` on build, or in the
 ``singularity.conf`` configuration file if required.
 
 .. note::
 
-   Running Singularity in non-setuid mode requires unprivileged user
+   Running {Singularity} in non-setuid mode requires unprivileged user
    namespace support in the operating system kernel and does not
    support all features, most notably direct mounts of SIF
    images. This impacts integrity/security guarantees of containers at
    runtime.
 
    See the :ref:`non-setuid installation section <install-nonsetuid>` for further
-   detail on how to install singularity to run in non-setuid mode.
+   detail on how to install {Singularity} to run in non-setuid mode.
 
 ------------------------
 Installation from Source
 ------------------------
 
-Singularity Community Edition can be installed from source directly,
-or by building an RPM package from the source. Various Linux
-distributions also package Singularity, but their packages may not be
+{Singularity} can be installed from source directly,
+or by building an RPM package from the source. Linux
+distributions may also package {Singularity}, but their packages may not be
 up-to-date with the upstream version on GitHub.
 
-To install Singularity directly from source, follow the procedure
+To install {Singularity} directly from source, follow the procedure
 below. Other methods are discussed in the :ref:`Installation
 <installation>` section.
 
 .. Note::
    
     This quick-start that you will install as ``root`` using
-    ``sudo``, so that Singularity uses the default ``setuid``
+    ``sudo``, so that {Singularity} uses the default ``setuid``
     workflow, and all features are available. See the :ref:`non-setuid
     installation <install-nonsetuid>` section of this guide for detail
     of how to install as a non-root user, and how this affects the
-    functionality of Singularity.
+    functionality of {Singularity}.
 
  
 Install Dependencies
@@ -144,9 +144,9 @@ On Ubuntu or Debian install the following dependencies:
 Install Go
 ----------
 
-Singularity v3 is written primarily in Go, and you will need Go 1.13
+{Singularity} v3 is written primarily in Go, and you will need Go 1.13
 or above installed to compile it from source. Versions of Go packaged
-by your distribution may not be new enough to build Singularity.
+by your distribution may not be new enough to build {Singularity}.
 
 The method below is one of several ways to `install and configure Go
 <https://golang.org/doc/install>`_.
@@ -183,10 +183,10 @@ Then, set up your environment for Go.
         source ~/.bashrc
 
 
-Download Singularity from a GitHub release
-------------------------------------------
+Download {Singularity} from a GitHub release
+--------------------------------------------
 
-You can download Singularity from one of the releases. To see a full list, visit
+You can download {Singularity} from one of the releases. To see a full list, visit
 `the GitHub release page <https://github.com/hpcng/singularity/releases>`_.
 After deciding on a release to install, you can run the following commands to
 proceed with the installation.
@@ -199,10 +199,10 @@ proceed with the installation.
         cd singularity
 
 
-Compile & Install Singularity
------------------------------
+Compile & Install {Singularity}
+-------------------------------
 
-Singularity uses a custom build system called ``makeit``.  ``mconfig`` is called
+{Singularity} uses a custom build system called ``makeit``.  ``mconfig`` is called
 to generate a ``Makefile`` and then ``make`` is used to compile and install.
 
 .. code-block:: none
@@ -211,7 +211,7 @@ to generate a ``Makefile`` and then ``make`` is used to compile and install.
         make -C ./builddir && \
         sudo make -C ./builddir install
 
-By default Singularity will be installed in the ``/usr/local`` directory
+By default {Singularity} will be installed in the ``/usr/local`` directory
 hierarchy. You can specify a custom directory with the ``--prefix`` option, to
 ``mconfig``:
 
@@ -220,12 +220,12 @@ hierarchy. You can specify a custom directory with the ``--prefix`` option, to
     $ ./mconfig --prefix=/opt/singularity
 
 This option can be useful if you want to install multiple versions of
-Singularity, install a personal version of Singularity on a shared system, or if
-you want to remove Singularity easily after installing it.
+Singularity, install a personal version of {Singularity} on a shared system, or if
+you want to remove {Singularity} easily after installing it.
 
 For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
 are some of the most common options that you may need to use when
-building Singularity from source.
+building {Singularity} from source.
 
 - ``--sysconfdir``: Install read-only config files in sysconfdir.
   This option is important if you need the ``singularity.conf`` file
@@ -233,37 +233,37 @@ building Singularity from source.
 
 - ``--localstatedir``: Set the state directory where containers are
   mounted. This is a particularly important option for administrators
-  installing Singularity on a shared file system.  The
+  installing {Singularity} on a shared file system.  The
   ``--localstatedir`` should be set to a directory that is present on
   each individual node.
 
-- ``-b``: Build Singularity in a given directory. By default this is
+- ``-b``: Build {Singularity} in a given directory. By default this is
   ``./builddir``.
 
 -------------
 Configuration
 -------------
 
-Singularity is configured using files under ``etc/singularity`` in
+{Singularity} is configured using files under ``etc/singularity`` in
 your ``--prefix``, or ``--syconfdir`` if you used that option with
 ``mconfig``. In a default installation from source without a
 ``--prefix`` set you will find them under
 ``/usr/local/etc/singularity``.
 
-You can edit these files directly, or using the ``singularity config
+You can edit these files directly, or using the ``{Singularity} config
 global`` command as the root user to manage them.
 
 ``singularity.conf`` contains the majority of options controlling the
-runtime behaviour of Singularity. Additional files control security,
+runtime behaviour of {Singularity}. Additional files control security,
 network, and resource configuration. Head over to the
 :ref:`Configuration files <singularity_configfiles>` section where the
 files and configuration options are discussed.
 
-----------------
-Test Singularity
-----------------
+------------------
+Test {Singularity}
+------------------
 
-You can run a quick test of Singularity using a container in the
+You can run a quick test of {Singularity} using a container in the
 Sylabs Container Library:
 
 .. code-block:: none
@@ -274,4 +274,4 @@ Sylabs Container Library:
 
 See the `user guide
 <\{userdocs\}>`__ for more
-information about how to use Singularity.
+information about how to use {Singularity}.

--- a/appendix.rst
+++ b/appendix.rst
@@ -5,7 +5,7 @@
 Installed Files
 ===============
 
-An installation of Singularity {InstallationVersion}, performed as root via
+An installation of {Singularity} {InstallationVersion}, performed as root via
 ``sudo make install`` consists of the following files, with ownership
 and permissions required to use the `setuid` workflow:
 

--- a/conf.py
+++ b/conf.py
@@ -244,7 +244,7 @@ latex_logo = 'logo.png'
 
 # The title of the document. It defaults to the html_title option
 # but can be set independently for epub creation.
-epub_title = 'Singularity ' + version + ' Administrator Guide'
+epub_title = '{Singularity}  ' + version + ' Administrator Guide'
 
 # The author of the document. This is put in the Dublin Core metadata.
 # It defaults to the author option.

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -1,27 +1,27 @@
 .. _singularity_configfiles:
 
-===============================
-Singularity Configuration Files
-===============================
+=================================
+{Singularity} Configuration Files
+=================================
 
-As a Singularity Administrator, you will have access to various configuration
+As a {Singularity} Administrator, you will have access to various configuration
 files, that will let you manage container resources, set security restrictions
-and configure network options etc, when installing Singularity across the system.
+and configure network options etc, when installing {Singularity} across the system.
 All these files can be found in ``/usr/local/etc/singularity`` by default (though
 its location will obviously differ based on options passed during the
 installation). This page will describe the following configuration files and
 the various parameters contained by them. They are usually self documenting
 but here are several things to pay special attention to:
 
------------------
+----------------
 singularity.conf
------------------
+----------------
 Most of the configuration options are set using the file ``singularity.conf``
-that defines the global configuration for Singularity across the entire system.
+that defines the global configuration for {Singularity} across the entire system.
 Using this file, system administrators can have direct say as to what functions
 the users can utilize. As a security measure, for ``setuid`` installations of
-Singularity it must be owned by root and must not be writable by users or
-Singularity will refuse to run. This is not the case for ``non-setuid``
+{Singularity} it must be owned by root and must not be writable by users or
+{Singularity} will refuse to run. This is not the case for ``non-setuid``
 installations that will only ever execute with user priviledge and thus do not
 require such limitations. The options for this configuration are listed below.
 Options are grouped together based on relevance, the order of options within
@@ -31,17 +31,17 @@ Setuid and Capabilities
 =======================
 
 ``ALLOW SETUID``:
-To use all features of Singularity containers, Singularity will need to have
-access to some privileged system calls. One way singularity achieves this is by
+To use all features of {Singularity} containers, {Singularity} will need to have
+access to some privileged system calls. One way {Singularity} achieves this is by
 using binaries with the ``setuid`` bit enabled. This variable lets you
-enable/disable users ability to utilize these binaries within Singularity. By
-default, it is set to "yes", but when disabled, various Singularity features
+enable/disable users ability to utilize these binaries within {Singularity}. By
+default, it is set to "yes", but when disabled, various {Singularity} features
 will not function. Please see
 :ref:`Unprivileged Installations <userns-limitations>` for more information
-about running Singularity without ``setuid`` enabled.
+about running {Singularity} without ``setuid`` enabled.
 
 ``ROOT DEFAULT CAPABILITIES``:
-Singularity allows the specification of capabilities kept by the root user
+{Singularity} allows the specification of capabilities kept by the root user
 when running a container by default. Options include:
 
 * full: all capabilities are maintained, this gives the same behavior as the ``--keep-privs`` option.
@@ -58,12 +58,12 @@ when running a container by default. Options include:
 Loop Devices
 ============
 
-Singularity uses loop devices to facilitate the mounting of container
+{Singularity} uses loop devices to facilitate the mounting of container
 filesystems from SIF images.
 
 ``MAX LOOP DEVICES``:
 This option allows an admin to limit the total number of loop devices
-Singularity will consume at a given time.
+{Singularity} will consume at a given time.
 
 ``SHARED LOOP DEVICES``:
 This allows containers running the same image to share a single loop device.
@@ -84,31 +84,31 @@ their containers through the ``--pid`` flag.
 Configuration Files
 ===================
 
-Singularity allows for the automatic configuration of several system
+{Singularity} allows for the automatic configuration of several system
 configuration files within containers to ease usage across systems.
 
 .. note::
 
   These options will do nothing unless the file or directory path exists within
-  the container or Singularity has either overlay or underlay support enabled.
+  the container or {Singularity} has either overlay or underlay support enabled.
 
 ``CONFIG PASSWD``:
-This option determines if Singularity should automatically append an entry to
+This option determines if {Singularity} should automatically append an entry to
 ``/etc/passwd`` for the user running the container.
 
 ``CONFIG GROUP``:
-This option determines if Singularity should automatically append the calling
+This option determines if {Singularity} should automatically append the calling
 user's group entries to the containers ``/etc/group``.
 
 ``CONFIG RESOLV_CONF``:
-This option determines if Singularity should automatically bind the host's
+This option determines if {Singularity} should automatically bind the host's
 ``/etc/resolv/conf`` within the container.
 
 Session Directory and System Mounts
 ===================================
 
 ``SESSIONDIR MAX SIZE``:
-In order for the Singularity runtime to create a container it needs to create a
+In order for the {Singularity} runtime to create a container it needs to create a
 ``sessiondir`` to manage various components of the container, including
 mounting filesystems over the base image filesystem. This option
 specifies how large the default ``sessiondir`` should be (in MB) and will
@@ -117,20 +117,20 @@ location to perform default read/writes to via the ``--workdir`` or ``--home``
 options.
 
 ``MOUNT PROC``:
-This option determines if Singularity should automatically bind mount ``/proc``
+This option determines if {Singularity} should automatically bind mount ``/proc``
 within the container.
 
 ``MOUNT SYS``:
-This option determines if Singularity should automatically bind mount ``/sys``
+This option determines if {Singularity} should automatically bind mount ``/sys``
 within the container.
 
 ``MOUNT DEV``:
-Should be set to "YES", if you want Singularity to automatically bind mount
+Should be set to "YES", if you want {Singularity} to automatically bind mount
 `/dev` within the container. If set to 'minimal', then only 'null', 'zero',
 'random', 'urandom', and 'shm' will be included.
 
 ``MOUNT DEVPTS``:
-This option determines if Singularity will mount a new instance of ``devpts``
+This option determines if {Singularity} will mount a new instance of ``devpts``
 when there is a ``minimal`` ``/dev`` directory as explained above, or when the
 ``--contain`` option is passed.
 
@@ -140,22 +140,22 @@ when there is a ``minimal`` ``/dev`` directory as explained above, or when the
   ``4.7``.
 
 ``MOUNT HOME``:
-When this option is enabled, Singularity will automatically determine the
+When this option is enabled, {Singularity} will automatically determine the
 calling user's home directory and attempt to mount it into the container.
 
 ``MOUNT TMP``:
-When this option is enabled, Singularity will automatically bind mount
+When this option is enabled, {Singularity} will automatically bind mount
 ``/tmp`` and ``/var/tmp`` into the container from the host. If the
-``--contain`` option is passed, Singularity will create both locations within
+``--contain`` option is passed, {Singularity} will create both locations within
 the ``sessiondir`` or within the directory specified by the ``--workdir``
 option if that is passed as well.
 
 ``MOUNT HOSTFS``:
-This option will cause Singularity to probe the host for all mounted
+This option will cause {Singularity} to probe the host for all mounted
 filesystems and bind those into containers at runtime.
 
 ``MOUNT SLAVE``:
-Singularity automatically mounts a handful host system directories to the
+{Singularity} automatically mounts a handful host system directories to the
 container by default. This option determines if filesystem changes on the host
 should automatically be propogated to those directories in the container.
 
@@ -165,7 +165,7 @@ should automatically be propogated to those directories in the container.
 
 ``MEMORY FS TYPE``:
 This option allows admins to choose the temporary filesystem used by
-Singularity. Temporary filesystems are primarily used for system
+{Singularity}. Temporary filesystems are primarily used for system
 directories like ``/dev`` when the host system directory is not mounted
 within the container.
 
@@ -180,9 +180,9 @@ Bind Mount Management
 
 ``BIND PATH``:
 This option is used for defining a list of files or directories to
-automatically be made available when Singularity runs a container.
+automatically be made available when {Singularity} runs a container.
 In order to successfully mount listed paths the file or directory path must
-exist within the container, or Singularity has either overlay or underlay
+exist within the container, or {Singularity} has either overlay or underlay
 support enabled.
 
 .. note::
@@ -219,7 +219,7 @@ the specified user.
 
 .. note::
 
-  This feature will only apply when Singularity is running in SUID mode and the
+  This feature will only apply when {Singularity} is running in SUID mode and the
   user is non-root. By default this is set to `NULL`.
 
 ``LIMIT CONTAINER GROUPS``:
@@ -228,7 +228,7 @@ the specified group.
 
 .. note::
 
-  This feature will only apply when Singularity is running in SUID mode and the
+  This feature will only apply when {Singularity} is running in SUID mode and the
   user is non-root. By default this is set to `NULL`.
 
 ``LIMIT CONTAINER PATHS``:
@@ -237,12 +237,12 @@ within the specified path prefix.
 
 .. note::
 
-  This feature will only apply when Singularity is running in SUID mode and the
+  This feature will only apply when {Singularity} is running in SUID mode and the
   user is non-root. By default this is set to `NULL`.
 
 ``ALLOW CONTAINER ${TYPE}``:
 This option allows admins to limit the types of image formats that can be
-leveraged by users with Singularity. Formats include ``squashfs`` which is used
+leveraged by users with {Singularity}. Formats include ``squashfs`` which is used
 by SIF and v2.x Singularity images, ``extfs`` which is used for writable
 overlays and some legacy Singularity images, ``dir`` which is used by sandbox
 images and ``encrypted`` which is only used by SIF images to encrypt filesystem
@@ -261,7 +261,7 @@ virtualization
 use of CNI network configurations requires root privilege, as certain
 configurations may disrupt the host networking environment.
 
-Singularity 3.8 allows specific users or groups to be granted the
+{Singularity} 3.8 allows specific users or groups to be granted the
 ability to run containers with adminstrator specified CNI
 configurations.
 
@@ -269,26 +269,26 @@ configurations.
 Allow specified root administered CNI network configurations to be used by the
 specified list of users. By default only root may use CNI configuration,
 except in the case of a fakeroot execution where only 40_fakeroot.conflist
-is used. This feature only applies when Singularity is running in
+is used. This feature only applies when {Singularity} is running in
 SUID mode and the user is non-root.
 
 ``ALLOW NET GROUPS``:
 Allow specified root administered CNI network configurations to be used by the
 specified list of users. By default only root may use CNI configuration,
 except in the case of a fakeroot execution where only 40_fakeroot.conflist
-is used. This feature only applies when Singularity is running in
+is used. This feature only applies when {Singularity} is running in
 SUID mode and the user is non-root.
 
 ``ALLOW NET NETWORKS``:
 Specify the names of CNI network configurations that may be used by users and
 groups listed in the allow net users / allow net groups directives. Thus feature
-only applies when Singularity is running in SUID mode and the user is non-root.
+only applies when {Singularity} is running in SUID mode and the user is non-root.
 
 
 GPU Options
 ===========
 
-Singularity provides integration with GPUs in order to facilitate GPU based
+{Singularity} provides integration with GPUs in order to facilitate GPU based
 workloads seamlessly. Both options listed below are particularly useful in
 GPU only environments. For more information on using GPUs with Singularity
 checkout :ref:`GPU Library Configuration <gpu_library_configuration>`.
@@ -311,13 +311,13 @@ This will allow users to mount fuse filesystems inside containers using the
 ``--fusemount`` flag.
 
 ``ENABLE OVERLAY``:
-This option will allow Singularity to create bind mounts at paths that do not
+This option will allow {Singularity} to create bind mounts at paths that do not
 exist within the container image. This option can be set to ``try``, which will
 try to use an overlayfs. If it fails to create an overlayfs in this case the
 bind path will be silently ignored.
 
 ``ENABLE UNDERLAY``:
-This option will allow Singularity to create bind mounts at paths that do not
+This option will allow {Singularity} to create bind mounts at paths that do not
 exist within the container image, just like ``ENABLE OVERLAY``, but instead
 using an underlay. This is suitable for systems where overlay is not possible
 or not working. If the overlay option is available and working, it will be
@@ -326,16 +326,16 @@ used instead.
 External Tooling Paths
 ======================
 
-Internally, Singularity leverages several pieces of tooling in order to provide
+Internally, {Singularity} leverages several pieces of tooling in order to provide
 a wide breadth of features for users. Locations for these tools can be
 customized by system admins and referenced with the options below:
 
 ``CNI CONFIGURATION PATH``:
 This option allows admins to specify a custom path for the CNI configuration
-that Singularity will use for `Network Virtualization <\{userdocs\}/networking.html>`_.
+that {Singularity} will use for `Network Virtualization <\{userdocs\}/networking.html>`_.
 
 ``CNI PLUGIN PATH``:
-This option allows admins to specify a custom path for Singularity to access
+This option allows admins to specify a custom path for {Singularity} to access
 CNI plugin executables. Check out the `Network Virtualization <\{userdocs\}/networking.html>`_
 section of the user guide for more information.
 
@@ -345,7 +345,7 @@ installed in a standard location. If set, ``mksquashfs`` at this path will be
 used instead of a ``mksquashfs`` found in ``PATH``.
 
 ``CRYPTSETUP PATH``:
-The location for ``cryptsetup`` is recorded by Singularity at build time and
+The location for ``cryptsetup`` is recorded by {Singularity} at build time and
 will use that value if this is undefined. This option allows an admin to set
 the path of ``cryptsetup`` if it is located in a custom location and will
 override the value recorded at build time.
@@ -353,7 +353,7 @@ override the value recorded at build time.
 Updating Configuration Options
 ==============================
 
-In order to manage this configuration file, Singularity has a ``config global``
+In order to manage this configuration file, {Singularity} has a ``config global``
 command group that allows you to get, set, reset, and unset values through the
 CLI. It's important to note that these commands must be run with elevated
 priveledges because the ``singularity.conf`` can only be modified by an
@@ -620,8 +620,8 @@ are allowed to run.
 .. note::
 
     The ECL checks will use the new signature format introduced in
-    Singularity 3.6.0. Containers signed with older versions of Singularity
-    Singularity will not pass ECL checks.
+    {Singularity} 3.6.0. Containers signed with older versions of Singularity
+    {Singularity} will not pass ECL checks.
 
     To temporarily permit the use of legacy insecure signatures, set
     ``legacyinsecure = true`` in ``ecl.toml``.
@@ -629,9 +629,9 @@ are allowed to run.
 Managing ECL public keys
 ========================
 
-In Singularity 3.6, public keys associated with fingerprints specified in ECL rules
+In {Singularity} 3.6, public keys associated with fingerprints specified in ECL rules
 were required to be present in user's local keyring which is not very
-convenient. Singularity 3.7.0 provides a mechanism to administrators for managing
+convenient. {Singularity} 3.7.0 provides a mechanism to administrators for managing
 a global keyring that ECL uses during signature verification, for that purpose a
 ``--global`` option was added for:
 
@@ -652,7 +652,7 @@ a global keyring that ECL uses during signature verification, for that purpose a
 GPU Library Configuration
 -------------------------
 
-When a container includes a GPU enabled application, Singularity (with
+When a container includes a GPU enabled application, {Singularity} (with
 the ``--nv`` or ``--rocm`` options) can properly inject the required
 Nvidia or AMD GPU driver libraries into the container, to match the
 host's kernel. The GPU ``/dev`` entries are provided in containers run
@@ -677,7 +677,7 @@ binaries on the host system.
 
 If ``nvidia-container-cli`` is not present, the ``nvliblist.conf``
 file is used to specify libraries and executables that need to be
-injected into the container when running Singularity with the ``--nv``
+injected into the container when running {Singularity} with the ``--nv``
 Nvidia GPU support option. The default ``nvliblist.conf`` is suitable
 for CUDA 10.1, but may need to be modified if you need to include
 additional libraries, or further libraries are added to newer versions
@@ -688,7 +688,7 @@ AMD Radeon GPUs / ROCm
 
 The ``rocmliblist.conf`` file is used to specify libraries and
 executables that need to be injected into the container when running
-Singularity with the ``--rocm`` Radeon GPU support option. The default
+{Singularity} with the ``--rocm`` Radeon GPU support option. The default
 ``rocmliblist.conf`` is suitable for ROCm 2.10, but may need to modified
 if you need to include additional libraries, or further libraries are
 added to newer versions of the ROCm distribution.
@@ -743,9 +743,9 @@ capability.json
      similar use cases, the :ref:`fakeroot feature <fakeroot>` is a better
      option.
 
-Singularity provides full support for admins to grant and revoke Linux
+{Singularity} provides full support for admins to grant and revoke Linux
 capabilities on a user or group basis. The ``capability.json`` file is
-maintained by Singularity in order to manage these capabilities. The
+maintained by {Singularity} in order to manage these capabilities. The
 ``capability`` command group allows you to ``add``, ``drop``, and ``list``
 capabilities for users and groups.
 
@@ -760,7 +760,7 @@ To do so, we would issue a command such as this:
     $ sudo singularity capability add --user pinger CAP_NET_RAW
 
 This means the user ``pinger`` has just been granted permissions (through Linux
-capabilities) to open raw sockets within Singularity containers.
+capabilities) to open raw sockets within {Singularity} containers.
 
 We can check that this change is in effect with the ``capability list``
 command.
@@ -785,14 +785,14 @@ the capability when executing a container with the ``--add-caps`` flag.
     rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
 
 If we decide that it is no longer necessary to allow the user ``pinger``
-to open raw sockets within Singularity containers, we can revoke the
+to open raw sockets within {Singularity} containers, we can revoke the
 appropriate Linux capability like so:
 
 .. code-block:: none
 
     $ sudo singularity capability drop --user pinger CAP_NET_RAW
 
-Now if ``pinger`` tries to use ``CAP_NET_RAW``, Singularity will not give the
+Now if ``pinger`` tries to use ``CAP_NET_RAW``, {Singularity} will not give the
 capability to the container and ``ping`` will fail to create a socket:
 
 .. code-block:: none
@@ -826,7 +826,7 @@ matches the filter rule and you can set it to ``SCMP_ACT_ERRNO`` which will have
 the thread receive a return value of *errno* if it calls a system call that matches
 the filter rule.
 The file is formatted in a way that it can take a list of additional system calls
-for different architecture and Singularity will automatically take syscalls
+for different architecture and {Singularity} will automatically take syscalls
 related to the current architecture where it's been executed.
 The ``include``/``exclude``-> ``caps`` section will include/exclude the listed
 system calls if the user has the associated capability.
@@ -860,14 +860,14 @@ Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/library/guide#create>`_ their container
 images with others.
 
-Singularity allows users to login to an account on the Sylabs Cloud, or
-configure Singularity to use an API compatable container service such as
-a local installation of Singularity Enterprise, which provides an on-premise
+{Singularity} allows users to login to an account on the Sylabs Cloud, or
+configure {Singularity} to use an API compatable container service such as
+a local installation of {Singularity} Enterprise, which provides an on-premise
 private Container Library, Remote Builder and Key Store.
 
 .. note::
 
-   A fresh installation of Singularity is automatically configured
+   A fresh installation of {Singularity} is automatically configured
    to connect to the public `Sylabs Cloud <https://cloud.sylabs.io>`__
    services.
 
@@ -892,7 +892,7 @@ Conversely, to remove a system-wide endpoint:
     [sudo] password for dave:
     INFO:    Remote "company-remote" removed.
 
-Singularity 3.7 introduces the ability for an administrator to make a remote
+{Singularity} 3.7 introduces the ability for an administrator to make a remote
 the only usable remote for the system by using the ``--exclusive`` flag:
 
 .. code-block:: none
@@ -931,7 +931,7 @@ please check the `Remote Userdocs <\{userdocs\}/endpoint.html>`_.
 Keyserver Configuration
 =======================
 
-By default, Singularity will use the keyserver correlated to the active cloud
+By default, {Singularity} will use the keyserver correlated to the active cloud
 service endpoint. This behavior can be changed or supplemented via the
 ``add-keyserver`` and ``remove-keyserver`` commands. These commands allow an
 administrator to create a global list of key servers used to verify container

--- a/index.rst
+++ b/index.rst
@@ -2,21 +2,21 @@
 Admin Guide
 ===========
 
-Welcome to the Singularity Admin Guide!
+Welcome to the {Singularity} Admin Guide!
 
 This guide aims to cover installation instructions, configuration
 detail, and other topics important to system adminstrators working
-with Singularity.
+with {Singularity}.
 
 See the `user guide
 <\{userdocs\}>`__ for more
-information about how to use Singularity.
+information about how to use {Singularity}.
 
 .. toctree::
    :maxdepth: 2
 
    Admin Quickstart <admin_quickstart>
-   Installing Singularity <installation>
+   Installing {Singularity} <installation>
    Configuration files <configfiles>
    User Namespaces & Fakeroot <user_namespace>
    Container Security <security>

--- a/installation.rst
+++ b/installation.rst
@@ -1,19 +1,19 @@
 .. _installation:
 
-######################
-Installing Singularity
-######################
+########################
+Installing {Singularity}
+########################
 
 This section will guide you through the process of installing
-Singularity {InstallationVersion} via several different methods. (For
-instructions on installing earlier versions of Singularity please see
+{Singularity} {InstallationVersion} via several different methods. (For
+instructions on installing earlier versions of {Singularity} please see
 `earlier versions of the docs <https://singularity.hpcng.org/docs/>`_.)
 
 =====================
 Installation on Linux
 =====================
 
-Singularity can be installed on any modern Linux distribution, on
+{Singularity} can be installed on any modern Linux distribution, on
 bare-metal or inside a Virtual Machine. Nested installations inside
 containers are not recommended, and require the outer container to be
 run with full privilege.
@@ -22,12 +22,12 @@ run with full privilege.
 System Requirements
 -------------------
 
-Singularity requires ~140MiB disk space once compiled and installed.
+{Singularity} requires ~140MiB disk space once compiled and installed.
 
 There are no specific CPU or memory requirements at runtime, though
 2GB of RAM is recommended when building from source.
 
-Full functionality of Singularity requires that the kernel supports:
+Full functionality of {Singularity} requires that the kernel supports:
 
  - **OverlayFS mounts** - (minimum kernel >=3.18) Required for full
    flexiblity in bind mounts to containers, and to support persistent
@@ -36,20 +36,20 @@ Full functionality of Singularity requires that the kernel supports:
    recommended) Required to run containers without root or setuid
    privilege.
 
-RHEL & CentOS 6 do not support these features, but Singularity can be
+RHEL & CentOS 6 do not support these features, but {Singularity} can be
 used with some limitations.
 
 
 Filesystem support / limitations
 ================================
 
-Singularity supports most filesystems, but there are some limitations
-when installing Singularity on, or running containers from, common
+{Singularity} supports most filesystems, but there are some limitations
+when installing {Singularity} on, or running containers from, common
 parallel / network filesystems. In general:
 
- - We strongly recommend installing Singularity on local disk on each
+ - We strongly recommend installing {Singularity} on local disk on each
    compute node.
- - If Singularity is installed to a network location, a
+ - If {Singularity} is installed to a network location, a
    ``--localstatedir`` should be provided on each node, and Singularity
    configured to use it.
  - The ``--localstatedir`` filesystem should support overlay mounts.
@@ -60,7 +60,7 @@ parallel / network filesystems. In general:
 
    Set the ``--localstatedir`` location by by providing
    ``--localstatedir my/dir`` as an option when you configure your
-   Singularity build with ``./mconfig``.
+   {Singularity} build with ``./mconfig``.
 
    Disk usage at the ``--localstatedir`` location is neglible
    (<1MiB). The directory is used as a location to mount the container
@@ -72,12 +72,12 @@ parallel / network filesystems. In general:
 Overlay support
 ---------------
    
-Various features of Singularity, such as the ``--writable-tmpfs`` and
+Various features of {Singularity}, such as the ``--writable-tmpfs`` and
 ``--overlay``, options use the Linux ``overlay`` filesystem driver to
 construct a container root filesystem that combines files from
 different locations. Not all filesystems can be used with the
 ``overlay`` driver, so when containers are run from these filesystems
-some Singularity features may not be available.
+some {Singularity} features may not be available.
 
 Overlay support has two aspects:
 
@@ -101,7 +101,7 @@ filesystem that supports overlay.
 Fakeroot / (sub)uid/gid mapping
 -------------------------------
 
-When Singularity is run using the :ref:`fakeroot <fakeroot>` option it
+When {Singularity} is run using the :ref:`fakeroot <fakeroot>` option it
 creates a user namespace for the container, and UIDs / GIDs in that
 user namepace are mapped to different host UID / GIDs.
 
@@ -114,10 +114,10 @@ aware of the mappings it will deny many operations, with 'permission
 denied' errors. This is currently a generic problem for rootless
 container runtimes.
 
-Singularity cache / atomic rename
----------------------------------
+{Singularity} cache / atomic rename
+-----------------------------------
 
-Singularity will cache SIF container images generated from remote
+{Singularity} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
 created at ``$HOME/.singularity/cache`` by default. The location of
 the cache can be changed by setting the ``SINGULARITY_CACHEDIR``
@@ -132,8 +132,8 @@ The directory used for ``SINGULARITY_CACHEDIR`` should be:
    container images anticipated.
  - Located on a filesystem that supports atomic rename, if possible.
 
-In Singularity version 3.6 and above the cache is concurrency safe.
-Parallel runs of Singularity that would create overlapping cache
+In {Singularity} version 3.6 and above the cache is concurrency safe.
+Parallel runs of {Singularity} that would create overlapping cache
 entries will not conflict, as long as the filesystem used by
 ``SINGULARITY_CACHEDIR`` supports atomic rename operations.
 
@@ -145,11 +145,11 @@ atomic to a single client, not across systems accessing the same NFS
 share.
 
 If you are not certain that your ``$HOME`` or ``SINGULARITY_CACHEDIR``
-filesytems support atomic rename, do not run Singularity in parallel
+filesytems support atomic rename, do not run ``singularity`` in parallel
 using remote container URLs. Instead use ``singularity pull`` to
 create a local SIF image, and then run this SIF image in a parallel
 step. An alternative is to use the ``--disable-cache`` option, but
-this will result in each Singularity instance independently fetching
+this will result in each {Singularity} instance independently fetching
 the container from the remote source, into a temporary location.
 
 
@@ -174,7 +174,7 @@ Lustre / GPFS
 -------------
 
 Lustre and GPFS do not have sufficient ``upperdir`` or ``lowerdir``
-overlay support for certain Singularity features, and do not support
+overlay support for certain {Singularity} features, and do not support
 user-namespace (sub)uid/gid mapping.
 
   - You cannot use ``-overlay`` or ``--writable-tmpfs`` with a sandbox
@@ -194,7 +194,7 @@ user-namespace (sub)uid/gid mapping.
 Before you begin
 ----------------
 
-If you have an earlier version of Singularity installed, you should
+If you have an earlier version of {Singularity} installed, you should
 :ref:`remove it <remove-an-old-version>` before executing the
 installation commands.  You will also need to install some
 dependencies and install `Go <https://golang.org/>`_.
@@ -205,7 +205,7 @@ dependencies and install `Go <https://golang.org/>`_.
 Install from Source
 -------------------
 
-To use the latest version of Singularity from GitHub you will need to
+To use the latest version of {Singularity} from GitHub you will need to
 build and install it from source. This may sound daunting, but the
 process is straightforward, and detailed below:
 
@@ -245,7 +245,7 @@ On Ubuntu or Debian install the following dependencies:
 
 .. note::
 
-   You can build Singularity (3.5+) without ``cryptsetup`` available, but will
+   You can build {Singularity} (3.5+) without ``cryptsetup`` available, but will
    not be able to use encrypted containers without it installed on your system.
 
 .. _install-go:
@@ -253,7 +253,7 @@ On Ubuntu or Debian install the following dependencies:
 Install Go
 ==========
 
-Singularity v3 is written primarily in Go, and you will need Go 1.13
+{Singularity} v3 is written primarily in Go, and you will need Go 1.13
 or above installed to compile it from source.
 
 This is one of several ways to `install and configure Go
@@ -290,10 +290,10 @@ Then, set up your environment for Go.
         echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
         source ~/.bashrc
 
-Download Singularity from a release
-===================================
+Download {Singularity} from a release
+=====================================
 
-You can download Singularity from one of the releases. To see a full
+You can download {Singularity} from one of the releases. To see a full
 list, visit `the GitHub release page
 <https://github.com/hpcng/singularity/releases>`_.  After deciding on
 a release to install, you can run the following commands to proceed
@@ -309,7 +309,7 @@ with the installation.
 Checkout Code from Git
 ======================
 
-The following commands will install Singularity from the `GitHub repo
+The following commands will install {Singularity} from the `GitHub repo
 <https://github.com/hpcng/singularity>`_ to ``/usr/local``. This
 method will work for >=v{InstallationVersion}. To install an older
 tagged release see `older versions of the docs
@@ -331,12 +331,12 @@ When installing from source, you can decide to install from either a
   code in a tagged point release.
 
 - **master branch**: The ``master`` branch contains the latest,
-  bleeding edge version of Singularity. This is the default branch
+  bleeding edge version of {Singularity}. This is the default branch
   when you clone the source code, so you don't have to check out any
   new branches to install it. The ``master`` branch changes quickly
   and may be unstable.
 
-To ensure that the Singularity source code is downloaded to the
+To ensure that the {Singularity} source code is downloaded to the
 appropriate directory use these commands.
 
 .. code-block:: none
@@ -348,7 +348,7 @@ appropriate directory use these commands.
 Compile Singularity
 ===================
 
-Singularity uses a custom build system called ``makeit``.  ``mconfig``
+{Singularity} uses a custom build system called ``makeit``.  ``mconfig``
 is called to generate a ``Makefile`` and then ``make`` is used to
 compile and install.
 
@@ -366,7 +366,7 @@ functionality :ref:`see below <install-nonsetuid>`.
         make -C ./builddir && \
         sudo make -C ./builddir install
 
-By default Singularity will be installed in the ``/usr/local``
+By default {Singularity} will be installed in the ``/usr/local``
 directory hierarchy. You can specify a custom directory with the
 ``--prefix`` option, to ``mconfig`` like so:
 
@@ -375,13 +375,13 @@ directory hierarchy. You can specify a custom directory with the
     $ ./mconfig --prefix=/opt/singularity
 
 This option can be useful if you want to install multiple versions of
-Singularity, install a personal version of Singularity on a shared
-system, or if you want to remove Singularity easily after installing
+{Singularity}, install a personal version of {Singularity} on a shared
+system, or if you want to remove {Singularity} easily after installing
 it.
 
 For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
 are some of the most common options that you may need to use when
-building Singularity from source.
+building {Singularity} from source.
 
 - ``--sysconfdir``: Install read-only config files in sysconfdir.
   This option is important if you need the ``singularity.conf`` file
@@ -389,11 +389,11 @@ building Singularity from source.
 
 - ``--localstatedir``: Set the state directory where containers are
   mounted. This is a particularly important option for administrators
-  installing Singularity on a shared file system.  The
+  installing {Singularity} on a shared file system.  The
   ``--localstatedir`` should be set to a directory that is present on
   each individual node.
 
-- ``-b``: Build Singularity in a given directory. By default this is
+- ``-b``: Build {Singularity} in a given directory. By default this is
   ``./builddir``.
 
 .. _install-nonsetuid:
@@ -402,9 +402,9 @@ building Singularity from source.
 Unprivileged (non-setuid) Installation
 ======================================
 
-If you need to install Singularity as a non-root user, or do not wish
+If you need to install {Singularity} as a non-root user, or do not wish
 to allow the use of a setuid root binary, you can configure
-singularity with the ``--without-suid`` option to mconfig:
+{Singularity} with the ``--without-suid`` option to mconfig:
 
 .. code-block:: none
 
@@ -412,12 +412,12 @@ singularity with the ``--without-suid`` option to mconfig:
         make -C ./builddir && \
         make -C ./builddir install
 
-If you have already installed Singularity you can disable the setuid
+If you have already installed {Singularity} you can disable the setuid
 flow by setting the option ``allow setuid = no`` in
 ``etc/singularity/singularity.conf`` within your installation
 directory.
 
-When singularity does not use setuid all container execution will use
+When {Singularity} does not use setuid all container execution will use
 a user namespace. This requires support from your operating system
 kernel, and imposes some limitations on functionality. You should
 review the :ref:`requirements <userns-requirements>` and
@@ -428,7 +428,7 @@ review the :ref:`requirements <userns-requirements>` and
 Source bash completion file
 ===========================
 
-To enjoy bash shell completion with Singularity commands and options,
+To enjoy bash shell completion with {Singularity} commands and options,
 source the bash completion file:
 
 .. code-block:: none
@@ -437,7 +437,7 @@ source the bash completion file:
 
 Add this command to your `~/.bashrc` file so that bash completion
 continues to work in new shells.  (Adjust the path if you
-installed Singularity to a different location.)
+installed {Singularity} to a different location.)
 
 .. _install-rpm:
 
@@ -446,8 +446,8 @@ Build and install an RPM
 ------------------------
 
 If you use RHEL, CentOS or SUSE, building and installing a Singularity
-RPM allows your Singularity installation be more easily managed,
-upgraded and removed. In Singularity >=v3.0.1 you can build an RPM
+RPM allows your {Singularity} installation be more easily managed,
+upgraded and removed. In {Singularity} >=v3.0.1 you can build an RPM
 directly from the `release tarball
 <https://github.com/hpcng/singularity/releases>`_.
 
@@ -490,7 +490,7 @@ following:
 
      It is very important to set the local state directory to a
      directory that physically exists on nodes within a cluster when
-     installing Singularity in an HPC environment with a shared file
+     installing {Singularity} in an HPC environment with a shared file
      system. 
 
 Build an RPM from Git source
@@ -524,10 +524,10 @@ dist`` to create a tarball that you can then build into an rpm with
 Remove an old version
 ---------------------
 
-In a standard installation of Singularity 3.0.1 and beyond (when
+In a standard installation of {Singularity} 3.0.1 and beyond (when
 building from source), the command ``sudo make install`` lists all the
 files as they are installed. You must remove all of these files and
-directories to completely remove Singularity.
+directories to completely remove {Singularity}.
 
 .. code-block:: none
 
@@ -539,40 +539,12 @@ directories to completely remove Singularity.
         /usr/local/bin/run-singularity \
         /usr/local/etc/bash_completion.d/singularity
 
-If you anticipate needing to remove Singularity, it might be easier to
+If you anticipate needing to remove {Singularity}, it might be easier to
 install it in a custom directory using the ``--prefix`` option to
-``mconfig``.  In that case Singularity can be uninstalled simply by
+``mconfig``.  In that case {Singularity} can be uninstalled simply by
 deleting the parent directory. Or it may be useful to install
-Singularity :ref:`using a package manager <install-rpm>` so that it
+{Singularity} :ref:`using a package manager <install-rpm>` so that it
 can be updated and/or uninstalled with ease in the future.
-
-------------------------------------
-Distribution packages of Singularity
-------------------------------------
-
-.. note::
-
-    Packaged versions of Singularity in Linux distribution repos are
-    maintained by community members. They may be older releases of
-    Singularity, as it can take time to package and distribute new
-    versions. For the latest upstream versions of Singularity it is
-    recommended that you build from source using one of the methods
-    detailed above.
-
-Install the CentOS/RHEL package using yum
-=========================================
-
-The EPEL (Extra Packages for Enterprise Linux) repos contain
-Singularity rpms that are regularly updated. To install Singularity
-from the epel repos, first install the epel-release package and then
-install Singularity.  For instance, on CentOS 6/7/8 do the following:
-
-.. code-block:: none
-
-    $ sudo yum update -y && \
-        sudo yum install -y epel-release && \
-        sudo yum update -y && \
-        sudo yum install -y singularity
 
 ------------------------------------------
 Testing & Checking the Build Configuration
@@ -590,14 +562,14 @@ library:
 
 See the `user guide
 <\{userdocs\}>`__ for more
-information about how to use Singularity.
+information about how to use {Singularity}.
 
 singularity buildcfg
 ====================
 
 Running ``singularity buildcfg`` will show the build configuration of
-an installed version of Singularity, and lists the paths used by
-Singularity. Use ``singularity buildcfg`` to confirm paths are set
+an installed version of {Singularity}, and lists the paths used by
+{Singularity}. Use ``singularity buildcfg`` to confirm paths are set
 correctly for your installation, and troubleshoot any 'not-found'
 errors at runtime.
 
@@ -631,13 +603,13 @@ Note that the ``LOCALSTATEDIR`` and ``SESSIONDIR`` should be on local,
 non-shared storage.
 
 The list of files installed by a successful `setuid` installation of
-Singularity can be found in the :ref:`appendix, installed files
+{Singularity} can be found in the :ref:`appendix, installed files
 section <installed-files>`.
 
 Test Suite
 ==========
 
-The Singularity codebase includes a test suite that is run during
+The {Singularity} codebase includes a test suite that is run during
 development using CI services.
 
 If you would like to run the test suite locally you can run the test
@@ -647,7 +619,7 @@ targets from the ``builddir`` directory in the source tree:
   - ``make unit-test`` runs basic unit tests
   - ``make integration-test`` runs integration tests
   - ``make e2e-test`` runs end-to-end tests, which exercise a large
-    number of operations by calling the singularity CLI with different
+    number of operations by calling the {Singularity} CLI with different
     execution profiles.
 
 .. note::
@@ -656,7 +628,7 @@ targets from the ``builddir`` directory in the source tree:
     and ``nc`` in order to test docker and instance/networking
     functionality.
 
-    Singularity must be installed in order to run the full
+    {Singularity} must be installed in order to run the full
     test suite, as it must run the CLI with setuid privilege for the 
     ``starter-suid`` binary.
 
@@ -671,21 +643,17 @@ targets from the ``builddir`` directory in the source tree:
 Installation on Windows or Mac
 ==============================
 
-Linux container runtimes like Singularity cannot run natively on
+Linux container runtimes like {Singularity} cannot run natively on
 Windows or Mac because of basic incompatibilities with the host
 kernel. (Contrary to a popular misconception, MacOS does not run on a
 Linux kernel. It runs on a kernel called Darwin originally forked
 from BSD.)
 
-For this reason, the Singularity community maintains a set of Vagrant
+For this reason, the {Singularity} community maintains a set of Vagrant
 Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one of
 `Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
 source tools. The current versions can be found under the `sylabs
 <https://app.vagrantup.com/sylabs>`_ organization.
-
-Sylabs has also developed a beta version of Singularity Desktop for
-Mac, which runs Singularity in a lightweight virtual machine, in a
-transparent manner.
 
 -------
 Windows
@@ -698,31 +666,9 @@ Install the following programs:
  -  `Vagrant for Windows <https://www.vagrantup.com/downloads.html>`_
  -  `Vagrant Manager for Windows <http://vagrantmanager.com/downloads/>`_
 
----
-Mac
----
-
-To use Singularity Desktop for macOS (Beta Preview):
-
-Download a Mac installer package `here
-<https://www.sylabs.io/singularity-desktop-macos/>`__.
-
-Singularity is also available via Vagrant (installable with
-`Homebrew <https://brew.sh>`_ or manually) or with the Singularity Desktop for
-macOS (Alpha Preview).
-
-To use Vagrant via Homebrew:
-
-.. code-block:: none
-
-    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    $ brew install --cask virtualbox && \
-        brew install --cask vagrant && \
-        brew install --cask vagrant-manager
-
------------------------        
-Singularity Vagrant Box
------------------------
+-------------------------        
+{Singularity} Vagrant Box
+-------------------------
 
 Run Git Bash (Windows) or open a terminal (Mac) and create and enter a
 directory to be used with your Vagrant VM.
@@ -745,12 +691,12 @@ different value for the ``$VM`` variable if you like.)
 
 .. code-block:: none
 
-    $ export VM=sylabs/singularity-3.7-ubuntu-bionic64 && \
+    $ export VM=sylabs/singularity-3.8-ubuntu-bionic64 && \
         vagrant init $VM && \
         vagrant up && \
         vagrant ssh
 
-You can check the installed version of Singularity with the following:
+You can check the installed version of {Singularity} with the following:
 
 .. code-block:: none
 
@@ -759,4 +705,4 @@ You can check the installed version of Singularity with the following:
 
 
 Of course, you can also start with a plain OS Vagrant box as a base and then
-install Singularity using one of the above methods for Linux.
+install {Singularity} using one of the above methods for Linux.

--- a/replacements.py
+++ b/replacements.py
@@ -1,19 +1,32 @@
 def variableReplace(app, docname, source):
     """
-    Takes the source on rst and replaces all the needed variables declared on variable_replacements structure
+    Takes the source on rst and replaces all the needed variables declared on
+    variable_replacements structure
     """
     result = source[0]
     for key in app.config.variable_replacements:
         result = result.replace(key, app.config.variable_replacements[key])
     source[0] = result
 
-#Add the needed variables to be replaced either on code or on text on the next dictionary structure.
+
+# Add the needed variables to be replaced either on code or on text on the next
+# dictionary structure.
 variable_replacements = {
-    "{InstallationVersion}" : "3.8.0",
-    "\{userdocs\}" : "https://singularity.hpcng.org/user-docs/3.8"
+    # This is used in install instructions, so should be a full version
+    "{InstallationVersion}" : "3.8.5",
+    "\{userdocs\}" : "https://singularity.hpcng.org/user-docs/3.8",
+    # The versions in the published guide URLs are for major.minor only
+    "{adminversion}": "3.8",
+    "{userversion}": "3.8",
+    # The 'Singularity' noun is now a replacement so we can have
+    # {Singularity}  rather than bare 'Singularity'... and HPCng can
+    # replace to SingularityPRO so that it is clearer where docs
+    # diverge a bit from Singularity<->SingularityPRO due to long-term backports etc.
+    "{Singularity}": "Singularity",
 }
 
-def setup(app):
-   app.add_config_value('variable_replacements', {}, True)
-   app.connect('source-read', variableReplace)
 
+def setup(app):
+    app.add_config_value('variable_replacements', {}, True)
+    app.connect('source-read', variableReplace)
+    app.add_css_file('custom.css')

--- a/security.rst
+++ b/security.rst
@@ -1,20 +1,20 @@
 .. _security:
 
-***********************************
-Security in Singularity Containers
-***********************************
+************************************
+Security in {Singularity} Containers
+************************************
 
 Containers are all the rage today for many good reasons. They are light weight, easy to spin-up and require reduced IT management resources as compared to hardware VM environments. More importantly, container technology facilitates advanced research computing by granting the ability to package software in highly portable and reproducible environments encapsulating all dependencies, including the operating system. But there are still some challenges to container security. 
 
 Singularity, which is a container paradigm created by necessity for scientific and application driven workloads, addresses some 
 core missions of containers : Mobility of Compute, Reproducibility, HPC support, and **Security**. This document intends to inform
-admins of different security features supported by Singularity.
+admins of different security features supported by {Singularity}.
 
-Singularity Runtime
-###################
+{Singularity} Runtime
+#####################
 
-The Singularity runtime enforces a unique security model that makes it appropriate for *untrusted users* to run *untrusted containers* 
-safely on multi-tenant resources. Because the Singularity runtime dynamically writes UID and GID information to the appropriate files 
+The {Singularity} runtime enforces a unique security model that makes it appropriate for *untrusted users* to run *untrusted containers* 
+safely on multi-tenant resources. Because the {Singularity} runtime dynamically writes UID and GID information to the appropriate files 
 within the container, the user remains the same *inside* and *outside* the container, i.e., if you're an unprivileged 
 user while entering the container, you'll remain an unprivileged user inside the container. A privilege separation model is in place
 to prevent users from escalating privileges once they are inside of a container. The container file system is mounted using the 
@@ -22,12 +22,12 @@ to prevent users from escalating privileges once they are inside of a container.
 for users to run containers and greatly simplifies things like reading and writing data to the host system with appropriate 
 ownership.
 
-It is also important to note that the philosophy of Singularity is *Integration* over *Isolation*. Most container run times strive 
-to isolate your container from the host system and other containers as much as possible. Singularity, on the 
+It is also important to note that the philosophy of {Singularity} is *Integration* over *Isolation*. Most container run times strive 
+to isolate your container from the host system and other containers as much as possible. {Singularity}, on the 
 other hand, assumes that the user’s primary goals are portability, reproducibility, and ease of use and that isolation is often a 
-tertiary concern. Therefore, Singularity only isolates the mount namespace by default, and will also bind mount several host 
+tertiary concern. Therefore, {Singularity} only isolates the mount namespace by default, and will also bind mount several host 
 directories such as ``$HOME`` and ``/tmp`` into the container at runtime. If needed, additional levels of isolation can be achieved
-by passing options causing Singularity to enter any or all of the other kernel namespaces and to prevent automatic bind mounting.
+by passing options causing {Singularity} to enter any or all of the other kernel namespaces and to prevent automatic bind mounting.
 These measures allow users to interact with the host system from within the container in sensible ways.
 
 Singularity Image Format (SIF)
@@ -38,8 +38,8 @@ pipeline.. i.e., at rest, in transit and while running. Hence, the SIF has been 
 
 A SIF file is an immutable container runtime image. It is a physical representation of the container environment itself. An 
 important component of SIF that elicits security feature is the ability to cryptographically sign a container, creating a signature
-block within the SIF file which can guarantee immutability and provide accountability as to who signed it. Singularity follows the 
-`OpenPGP <https://www.openpgp.org/>`_ standard to create and manage these keys. After building an image within Singularity, users can
+block within the SIF file which can guarantee immutability and provide accountability as to who signed it. {Singularity} follows the 
+`OpenPGP <https://www.openpgp.org/>`_ standard to create and manage these keys. After building an image within {Singularity}, users can
 ``singularity sign`` the container and push it to the Library along with its public PGP key(Stored in :ref:`Keystore <keystore>`) which 
 later can be verified (``singularity verify``) while pulling or downloading the image. This feature in particular 
 protects collaboration within and between systems and teams. 
@@ -47,13 +47,13 @@ protects collaboration within and between systems and teams.
 SIF Encryption
 **************
 
-In Singularity 3.4 and above the container root filesystem that
+In {Singularity} 3.4 and above the container root filesystem that
 resides in the squashFS partition of a SIF can be encrypted, rendering
 it's contents inaccessible without a secret. Unlike other platforms,
 where encrypted layers must be assembled into an unencrypted runtime
-directory on disk, Singularity mounts the encrypted root file system
+directory on disk, {Singularity} mounts the encrypted root file system
 directly from the SIF using Kernel dm-crypt/LUKS functionality, so
-that the content is not exposed on disk. Singularity containers
+that the content is not exposed on disk. {Singularity} containers
 provide a comparable level of security to LUKS2 full disk encryption
 commonly deployed on Linux server and desktop systems.
 
@@ -72,7 +72,7 @@ default LUKS cipher on the host. The current default cipher used by
 ``aes-xts-plain64`` with a 256 bit key size. The default key
 derivation function for LUKS2 is ``argon2i``.
 
-Singularity currently supports 2 types of secrets for encrypted
+{Singularity} currently supports 2 types of secrets for encrypted
 containers:
 
   - *Passphrase*: a text passphrase is passed directly to
@@ -99,7 +99,7 @@ containers:
 Admin Configurable Files
 #########################
 
-Singularity Administrators have the ability to access various configuration files, that will let them set security 
+{Singularity} Administrators have the ability to access various configuration files, that will let them set security 
 restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <configfiles.html#ecl-toml>`_ 
 which allows blacklisting and whitelisting of containers. You can find all the configuration files and their parameters
 documented `here <configfiles.html>`__. 
@@ -107,22 +107,22 @@ documented `here <configfiles.html>`__.
 cgroups support
 ****************
 
-Starting v3.0, Singularity added native support for ``cgroups``, allowing users to limit the resources their containers consume 
+Starting v3.0, {Singularity} added native support for ``cgroups``, allowing users to limit the resources their containers consume 
 without the help of a separate program like a batch scheduling system. This feature helps in preventing  DoS attacks where one 
 container seizes control of all available system resources in order to stop other containers from operating properly. 
 To utilize this feature, a user first creates a configuration file. An example configuration file is installed by default with 
-Singularity to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration 
+{Singularity} to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration 
 file and cgroups are configured accordingly. More about cgroups support `here <configfiles.html#cgroups-toml>`__.
 
 ``--security`` options
 ***********************
 
-Singularity supports a number of methods for specifying the security scope and context when running Singularity containers. 
+{Singularity} supports a number of methods for specifying the security scope and context when running {Singularity} containers. 
 Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine 
 grained control of security. Details about them are documented `here <\{userdocs\}/security_options.html>`__.
 
 Security in SCS
-################
+###############
 
 `Singularity Container Services (SCS) <https://cloud.sylabs.io/home>`_ consist of a Remote Builder, a Container Library, and a 
 Keystore. Taken together, the Singularity Container Services provide an end-to-end solution for packaging and distributing 
@@ -131,11 +131,11 @@ applications in secure and trusted containers.
 Remote Builder
 **************
 
-As mentioned earlier, the Singularity runtime prevents executing code with root-level permissions on the host system. But building a 
+As mentioned earlier, the {Singularity} runtime prevents executing code with root-level permissions on the host system. But building a 
 container requires elevated privileges that most production environments do not grant to users. `The Remote Builder <https://cloud.sylabs.io/builder>`_ 
 solves this challenge by allowing unprivileged users a service that can be used to build containers targeting one or more CPU 
 architectures. System administrators can use the system to monitor which users are building containers, and the contents of those 
-containers. Starting with Singularity 3.0, the CLI has native integration with the Build Service from version 3.0 onwards. In 
+containers. Starting with {Singularity} 3.0, the CLI has native integration with the Build Service from version 3.0 onwards. In 
 addition, a web GUI interface to the Build Service also exists, which allows users to build containers using only a web browser.
 
 .. note::
@@ -146,7 +146,7 @@ addition, a web GUI interface to the Build Service also exists, which allows use
 Container Library
 *****************
 
-The `Container Library <https://cloud.sylabs.io/library>`_ enables users to store and share Singularity container images based on 
+The `Container Library <https://cloud.sylabs.io/library>`_ enables users to store and share {Singularity} container images based on 
 the Singularity Image Format (SIF). A web front-end allows users to create new projects within the Container Library, edit 
 documentation associated with container images, and discover container images published by their peers.
 
@@ -155,7 +155,7 @@ documentation associated with container images, and discover container images pu
 Key Store
 *********
 
-The `Key Store <https://cloud.sylabs.io/keystore>`_ is a key management system offered by Sylabs that utilizes `OpenPGP implementation <https://gnupg.org/>`_ to facilitate sharing and maintaining of PGP public keys used to sign and verify Singularity container images. This service is based on the OpenPGP HTTP Keyserver Protocol (HKP), with several enhancements:
+The `Key Store <https://cloud.sylabs.io/keystore>`_ is a key management system offered by Sylabs that utilizes `OpenPGP implementation <https://gnupg.org/>`_ to facilitate sharing and maintaining of PGP public keys used to sign and verify {Singularity} container images. This service is based on the OpenPGP HTTP Keyserver Protocol (HKP), with several enhancements:
 
 - The Service requires connections to be secured with Transport Layer Security (TLS).
 - The Service implements token-based authentication, allowing only authenticated users to add or modify PGP keys.
@@ -184,4 +184,4 @@ Security is not a check box that one can tick and forget.  It’s an ongoing pro
 continues all the way through to ongoing security practices.  In addition to ensuring that containers are run without elevated 
 privileges where appropriate, and that containers are produced by trusted sources, users must monitor their containers for newly 
 discovered vulnerabilities and update when necessary just as they would with any other software. The Singularity community is constantly probing to 
-find and patch vulnerabilities within Singularity, and will continue to do so.
+find and patch vulnerabilities within {Singularity}, and will continue to do so.

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -17,9 +17,9 @@ can act as root inside a container to perform administrative tasks,
 without being root on the host outside.
 
 
-Singularity uses user namespaces in 3 situations:
+{Singularity} uses user namespaces in 3 situations:
 
- - When the ``setuid`` workflow is disabled or Singularity was
+ - When the ``setuid`` workflow is disabled or {Singularity} was
    installed without root.
  - When a container is run with the ``--userns`` option.
  - When ``--fakeroot`` is used to impersonate a root user when
@@ -68,11 +68,11 @@ Unprivileged Installations
 --------------------------
 
 As detailed in the :ref:`non-setuid installation <install-nonsetuid>`
-section, Singularity can be compiled or configured with the ``allow
+section, {Singularity} can be compiled or configured with the ``allow
 setuid = no`` option in ``singularity.conf`` to not perform privileged
 operations using the ``starter-setuid`` binary.
 
-When singularity does not use ``setuid`` all container execution will
+When {Singularity} does not use ``setuid`` all container execution will
 use a user namespace. In this mode of operation, some features are not
 available, and there are impacts to the security/integrity guarantees
 when running SIF container images:
@@ -83,7 +83,7 @@ when running SIF container images:
    modification of the container at runtime.
  - Filesystem image, and SIF-embedded persistent overlays cannot be
    used.
- - Encrypted containers cannot be used. Singularity mounts encrypted
+ - Encrypted containers cannot be used. {Singularity} mounts encrypted
    containers directly through the kernel, so that encrypted content
    is not extracted to disk. This requires the setuid workflow.
  - Fakeroot functionality will rely on external setuid root
@@ -96,7 +96,7 @@ when running SIF container images:
 
 The ``--userns`` option to `singularity run/exec/shell` will start a
 container using a user namespace, avoiding the setuid privileged
-workflow for container setup even if Singularity was compiled and
+workflow for container setup even if {Singularity} was compiled and
 configured to use setuid by default.
 
 The same limitations apply as in an unprivileged installation.
@@ -122,11 +122,11 @@ have no privilege on the host.
 Requirements
 ============
 
-In addition to user namespace support, Singularity must manipulate
+In addition to user namespace support, {Singularity} must manipulate
 ``subuid`` and ``subgid`` maps for the user namepsace it creates. By
 default this happens transparently in the setuid workflow. With
-unprivileged installations of Singularity or where ``allow setuid =
-no`` is set in ``singularity.conf``, Singularity attempts to use
+unprivileged installations of {Singularity} or where ``allow setuid =
+no`` is set in ``singularity.conf``, {Singularity} attempts to use
 external setuid binaries ``newuidmap`` and ``newgidmap``, so you
 need to install those binaries on your system.
 
@@ -138,7 +138,7 @@ Fakeroot relies on ``/etc/subuid`` and ``/etc/subgid`` files to find
 configured mappings from real user and group IDs, to a range of
 otherwise vacant IDs for each user on the host system that can be
 remapped in the usernamespace. A user must have an entry in these
-system configuration files to use the fakeroot feature. Singularity
+system configuration files to use the fakeroot feature. {Singularity}
 provides a :ref:`config fakeroot <config-fakeroot>` command to assist
 in managing these files, but it is important to understand how they
 work.
@@ -172,7 +172,7 @@ Same for ``/etc/subgid``:
 
 .. warning::
 
-  Singularity requires that a range of at least ``65536`` IDs is used
+  {Singularity} requires that a range of at least ``65536`` IDs is used
   for each mapping. Larger ranges may be defined without error.
 
   It is also important to ensure that the subuid and subgid ranges
@@ -254,7 +254,7 @@ configured to use a network veth pair.
 
 .. note::
 
-  Unprivileged installations of Singularity cannot use ``fakeroot``
+  Unprivileged installations of {Singularity} cannot use ``fakeroot``
   network as it requires privilege during container creation to setup
   the network.
 
@@ -263,7 +263,7 @@ configured to use a network veth pair.
 Configuration with ``config fakeroot``
 ======================================
 
-Singularity 3.5 and above provides a ``config fakeroot`` command that
+{Singularity} 3.5 and above provides a ``config fakeroot`` command that
 can be used by a root user to administer local system ``/etc/subuid``
 and ``/etc/subgid`` files in a simple manner. This allows users to be
 granted the ability to use Singularity's fakeroot functionality
@@ -281,7 +281,7 @@ existing mappings.
 
 .. note::
 
-  If you deploy Singularity to a cluster you will need to make
+  If you deploy {Singularity} to a cluster you will need to make
   arrangements to synchronize ``/etc/subuid`` and ``/etc/subgid``
   mapping files to all nodes.
 


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-admindocs#3
 which fixed
- sylabs/singularity-admindocs#4

The original PR description was:

> Use a replacement for the `Singularity` noun, so `SingularityCE` docs more clearly differentiate from older `Singularity` versions. Will also allows Sylabs SingularityPRO docs to use `SingularityPRO` as the noun, which is beneficial as the long term supported PRO versions can drift in content from the CE release due to backports through time.