### PR TITLE
Reformat rst source, from sylabs 28

### DIFF
--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -172,7 +172,7 @@ instructions on go installation page).
 
 .. code-block:: none
 
-    $ export VERSION=1.14.12 OS=linux ARCH=amd64 && \
+    $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
         wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
         sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
         rm go$VERSION.$OS-$ARCH.tar.gz

--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -2,8 +2,8 @@
 Admin Quick Start
 =================
 
-This quick start gives an overview of installation of {Singularity} from
-source, a description of the architecture of {Singularity}, and
+This quick start gives an overview of installation of {Singularity}
+from source, a description of the architecture of {Singularity}, and
 pointers to configuration files. More information, including alternate
 installation options and detailed configuration options can be found
 later in this guide.
@@ -14,10 +14,10 @@ later in this guide.
 Architecture of {Singularity}
 -----------------------------
 
-{Singularity} is designed to allow containers to be executed as if they
-were native programs or scripts on a host system. No daemon is
-required to build or run containers, and the security model is compatible
-with shared systems.
+{Singularity} is designed to allow containers to be executed as if
+they were native programs or scripts on a host system. No daemon is
+required to build or run containers, and the security model is
+compatible with shared systems.
 
 As a result, integration with clusters and schedulers such as Univa
 Grid Engine, Torque, SLURM, SGE, and many others is as simple as
@@ -62,8 +62,9 @@ features include:
    without extraction to disk. This means that the container can
    always be verified, even at runtime, and encrypted content is not
    exposed on disk.
- - Restrictions can be configured to limit the ownership, location, and
-   cryptographic signatures of containers that are permitted to be run.
+ - Restrictions can be configured to limit the ownership, location,
+   and cryptographic signatures of containers that are permitted to be
+   run.
 
 To support the SIF image format, automated networking setup etc., and
 older Linux distributions without user namespace support, Singularity
@@ -82,36 +83,38 @@ but :ref:`can be disabled <install-nonsetuid>` on build, or in the
    images. This impacts integrity/security guarantees of containers at
    runtime.
 
-   See the :ref:`non-setuid installation section <install-nonsetuid>` for further
-   detail on how to install {Singularity} to run in non-setuid mode.
+   See the :ref:`non-setuid installation section <install-nonsetuid>`
+   for further detail on how to install {Singularity} to run in
+   non-setuid mode.
 
 ------------------------
 Installation from Source
 ------------------------
 
-{Singularity} can be installed from source directly,
-or by building an RPM package from the source. Linux
-distributions may also package {Singularity}, but their packages may not be
-up-to-date with the upstream version on GitHub.
+{Singularity} can be installed from source directly, or by building an
+RPM package from the source. Linux distributions may also package
+{Singularity}, but their packages may not be up-to-date with the
+upstream version on GitHub.
 
 To install {Singularity} directly from source, follow the procedure
 below. Other methods are discussed in the :ref:`Installation
 <installation>` section.
 
 .. Note::
-   
-    This quick-start that you will install as ``root`` using
-    ``sudo``, so that {Singularity} uses the default ``setuid``
-    workflow, and all features are available. See the :ref:`non-setuid
-    installation <install-nonsetuid>` section of this guide for detail
-    of how to install as a non-root user, and how this affects the
-    functionality of {Singularity}.
 
- 
+    This quick-start that you will install as ``root`` using ``sudo``,
+    so that {Singularity} uses the default ``setuid`` workflow, and
+    all features are available. See the :ref:`non-setuid installation
+    <install-nonsetuid>` section of this guide for detail of how to
+    install as a non-root user, and how this affects the functionality
+    of {Singularity}.
+
+
 Install Dependencies
 --------------------
 
-On Red Hat Enterprise Linux or CentOS install the following dependencies:
+On Red Hat Enterprise Linux or CentOS install the following
+dependencies:
 
 .. code-block:: sh
 
@@ -125,7 +128,7 @@ On Red Hat Enterprise Linux or CentOS install the following dependencies:
         squashfs-tools \
         cryptsetup
 
-        
+
 On Ubuntu or Debian install the following dependencies:
 
 .. code-block:: sh
@@ -162,10 +165,10 @@ The method below is one of several ways to `install and configure Go
    versions.
 
 
-Visit the `Go download page <https://golang.org/dl/>`_ and pick a package
-archive to download. Copy the link address and download with wget.  Then extract
-the archive to ``/usr/local`` (or use other instructions on go installation
-page).
+Visit the `Go download page <https://golang.org/dl/>`_ and pick a
+package archive to download. Copy the link address and download with
+wget.  Then extract the archive to ``/usr/local`` (or use other
+instructions on go installation page).
 
 .. code-block:: none
 
@@ -186,10 +189,11 @@ Then, set up your environment for Go.
 Download {Singularity} from a GitHub release
 --------------------------------------------
 
-You can download {Singularity} from one of the releases. To see a full list, visit
-`the GitHub release page <https://github.com/hpcng/singularity/releases>`_.
-After deciding on a release to install, you can run the following commands to
-proceed with the installation.
+You can download {Singularity} from one of the releases. To see a full
+list, visit `the GitHub release page
+<https://github.com/hpcng/singularity/releases>`_.  After deciding on
+a release to install, you can run the following commands to proceed
+with the installation.
 
 .. code-block:: none
 
@@ -202,8 +206,9 @@ proceed with the installation.
 Compile & Install {Singularity}
 -------------------------------
 
-{Singularity} uses a custom build system called ``makeit``.  ``mconfig`` is called
-to generate a ``Makefile`` and then ``make`` is used to compile and install.
+{Singularity} uses a custom build system called ``makeit``.
+``mconfig`` is called to generate a ``Makefile`` and then ``make`` is
+used to compile and install.
 
 .. code-block:: none
 
@@ -211,17 +216,18 @@ to generate a ``Makefile`` and then ``make`` is used to compile and install.
         make -C ./builddir && \
         sudo make -C ./builddir install
 
-By default {Singularity} will be installed in the ``/usr/local`` directory
-hierarchy. You can specify a custom directory with the ``--prefix`` option, to
-``mconfig``:
+By default {Singularity} will be installed in the ``/usr/local``
+directory hierarchy. You can specify a custom directory with the
+``--prefix`` option, to ``mconfig``:
 
 .. code-block:: none
 
     $ ./mconfig --prefix=/opt/singularity
 
 This option can be useful if you want to install multiple versions of
-Singularity, install a personal version of {Singularity} on a shared system, or if
-you want to remove {Singularity} easily after installing it.
+Singularity, install a personal version of {Singularity} on a shared
+system, or if you want to remove {Singularity} easily after installing
+it.
 
 For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
 are some of the most common options that you may need to use when

--- a/appendix.rst
+++ b/appendix.rst
@@ -5,9 +5,9 @@
 Installed Files
 ===============
 
-An installation of {Singularity} {InstallationVersion}, performed as root via
-``sudo make install`` consists of the following files, with ownership
-and permissions required to use the `setuid` workflow:
+An installation of {Singularity} {InstallationVersion}, performed as
+root via ``sudo make install`` consists of the following files, with
+ownership and permissions required to use the `setuid` workflow:
 
 .. code-block:: none
 

--- a/conf.py
+++ b/conf.py
@@ -146,6 +146,9 @@ html_favicon = 'favicon.png'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['html/_static']
 
+# Custom bg color etc.
+html_css_files = ['css/custom.css']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -4,82 +4,90 @@
 {Singularity} Configuration Files
 =================================
 
-As a {Singularity} Administrator, you will have access to various configuration
-files, that will let you manage container resources, set security restrictions
-and configure network options etc, when installing {Singularity} across the system.
-All these files can be found in ``/usr/local/etc/singularity`` by default (though
-its location will obviously differ based on options passed during the
-installation). This page will describe the following configuration files and
-the various parameters contained by them. They are usually self documenting
-but here are several things to pay special attention to:
+As a {Singularity} Administrator, you will have access to various
+configuration files, that will let you manage container resources, set
+security restrictions and configure network options etc, when
+installing {Singularity} across the system.  All these files can be
+found in ``/usr/local/etc/singularity`` by default (though its
+location will obviously differ based on options passed during the
+installation). This page will describe the following configuration
+files and the various parameters contained by them. They are usually
+self documenting but here are several things to pay special attention
+to:
 
 ----------------
 singularity.conf
 ----------------
-Most of the configuration options are set using the file ``singularity.conf``
-that defines the global configuration for {Singularity} across the entire system.
-Using this file, system administrators can have direct say as to what functions
-the users can utilize. As a security measure, for ``setuid`` installations of
-{Singularity} it must be owned by root and must not be writable by users or
-{Singularity} will refuse to run. This is not the case for ``non-setuid``
-installations that will only ever execute with user priviledge and thus do not
-require such limitations. The options for this configuration are listed below.
-Options are grouped together based on relevance, the order of options within
-``singularity.conf`` differs.
+
+Most of the configuration options are set using the file
+``singularity.conf`` that defines the global configuration for
+{Singularity} across the entire system.  Using this file, system
+administrators can have direct say as to what functions the users can
+utilize. As a security measure, for ``setuid`` installations of
+{Singularity} it must be owned by root and must not be writable by
+users or {Singularity} will refuse to run. This is not the case for
+``non-setuid`` installations that will only ever execute with user
+priviledge and thus do not require such limitations. The options for
+this configuration are listed below.  Options are grouped together
+based on relevance, the order of options within ``singularity.conf``
+differs.
 
 Setuid and Capabilities
 =======================
 
-``allow setuid``:
-To use all features of {Singularity} containers, {Singularity} will need to have
-access to some privileged system calls. One way {Singularity} achieves this is by
-using binaries with the ``setuid`` bit enabled. This variable lets you
-enable/disable users ability to utilize these binaries within {Singularity}. By
-default, it is set to "yes", but when disabled, various {Singularity} features
-will not function. Please see
-:ref:`Unprivileged Installations <userns-limitations>` for more information
-about running {Singularity} without ``setuid`` enabled.
+``allow setuid``: To use all features of {Singularity} containers,
+{Singularity} will need to have access to some privileged system
+calls. One way {Singularity} achieves this is by using binaries with
+the ``setuid`` bit enabled. This variable lets you enable/disable
+users ability to utilize these binaries within {Singularity}. By
+default, it is set to "yes", but when disabled, various {Singularity}
+features will not function. Please see :ref:`Unprivileged
+Installations <userns-limitations>` for more information about running
+{Singularity} without ``setuid`` enabled.
 
-``root default capabilities``:
-{Singularity} allows the specification of capabilities kept by the root user
-when running a container by default. Options include:
+``root default capabilities``: {Singularity} allows the specification
+of capabilities kept by the root user when running a container by
+default. Options include:
 
-* full: all capabilities are maintained, this gives the same behavior as the ``--keep-privs`` option.
-* file: only capabilities granted in ``/usr/local/etc/singularity/capabilities/user.root`` are maintained.
-* no: no capabilities are maintained, this gives the same behavior as the ``--no-privs`` option.
+* full: all capabilities are maintained, this gives the same behavior
+  as the ``--keep-privs`` option.
+* file: only capabilities granted in
+  ``/usr/local/etc/singularity/capabilities/user.root`` are
+  maintained.
+* no: no capabilities are maintained, this gives the same behavior as
+  the ``--no-privs`` option.
 
 .. note::
 
-  The root user can manage the capabilities granted to individual containers when they
-  are launched through the ``--add-caps`` and ``drop-caps`` flags.
-  Please see `Linux Capabilities <\{userdocs\}/security_options.html#linux-capabilities>`_
+  The root user can manage the capabilities granted to individual
+  containers when they are launched through the ``--add-caps`` and
+  ``drop-caps`` flags.  Please see `Linux Capabilities
+  <\{userdocs\}/security_options.html#linux-capabilities>`_
   in the user guide for more information.
 
 Loop Devices
 ============
 
-{Singularity} uses loop devices to facilitate the mounting of container
-filesystems from SIF images.
+{Singularity} uses loop devices to facilitate the mounting of
+container filesystems from SIF images.
 
-``max loop devices``:
-This option allows an admin to limit the total number of loop devices
-{Singularity} will consume at a given time.
+``max loop devices``: This option allows an admin to limit the total
+number of loop devices {Singularity} will consume at a given time.
 
-``shared loop devices``:
-This allows containers running the same image to share a single loop device.
-This minimizes loop device usage and helps optimize kernel cache usage.
-Enabling this feature can be particularly useful for MPI jobs.
+``shared loop devices``: This allows containers running the same image
+to share a single loop device.  This minimizes loop device usage and
+helps optimize kernel cache usage.  Enabling this feature can be
+particularly useful for MPI jobs.
 
 Namespace Options
 =================
 
-``allow pid ns``:
-This option determines if users can leverage the PID namespace when running
-their containers through the ``--pid`` flag.
+``allow pid ns``: This option determines if users can leverage the PID
+namespace when running their containers through the ``--pid`` flag.
 
-.. note::
-  For some HPC systems, using the PID namespace has the potential of confusing
-  some resource managers as well as some MPI implementations.
+.. note:: For some HPC systems, using the PID namespace has the
+  potential of confusing some resource managers as well as some MPI
+  implementations.
 
 Configuration Files
 ===================
@@ -89,106 +97,107 @@ configuration files within containers to ease usage across systems.
 
 .. note::
 
-  These options will do nothing unless the file or directory path exists within
-  the container or {Singularity} has either overlay or underlay support enabled.
+  These options will do nothing unless the file or directory path
+  exists within the container or {Singularity} has either overlay or
+  underlay support enabled.
 
-``config passwd``:
-This option determines if {Singularity} should automatically append an entry to
-``/etc/passwd`` for the user running the container.
+``config passwd``: This option determines if {Singularity} should
+automatically append an entry to ``/etc/passwd`` for the user running
+the container.
 
-``config group``:
-This option determines if {Singularity} should automatically append the calling
-user's group entries to the containers ``/etc/group``.
+``config group``: This option determines if {Singularity} should
+automatically append the calling user's group entries to the
+containers ``/etc/group``.
 
-``config resolv_conf``:
-This option determines if {Singularity} should automatically bind the host's
-``/etc/resolv/conf`` within the container.
+``config resolv_conf``: This option determines if {Singularity} should
+automatically bind the host's ``/etc/resolv/conf`` within the
+container.
 
 Session Directory and System Mounts
 ===================================
 
-``sessiondir max size``:
-In order for the {Singularity} runtime to create a container it needs to create a
-``sessiondir`` to manage various components of the container, including
-mounting filesystems over the base image filesystem. This option
-specifies how large the default ``sessiondir`` should be (in MB) and will
-only affect users who use the ``--contain`` options without also specifying a
-location to perform default read/writes to via the ``--workdir`` or ``--home``
+``sessiondir max size``: In order for the {Singularity} runtime to
+create a container it needs to create a ``sessiondir`` to manage
+various components of the container, including mounting filesystems
+over the base image filesystem. This option specifies how large the
+default ``sessiondir`` should be (in MB) and will only affect users
+who use the ``--contain`` options without also specifying a location
+to perform default read/writes to via the ``--workdir`` or ``--home``
 options.
 
-``mount proc``:
-This option determines if {Singularity} should automatically bind mount ``/proc``
-within the container.
+``mount proc``: This option determines if {Singularity} should
+automatically bind mount ``/proc`` within the container.
 
 ``mount sys``:
 This option determines if {Singularity} should automatically bind mount ``/sys``
 within the container.
 
-``mount dev``:
-Should be set to "YES", if you want {Singularity} to automatically bind mount
-`/dev` within the container. If set to 'minimal', then only 'null', 'zero',
-'random', 'urandom', and 'shm' will be included.
+``mount dev``: Should be set to "YES", if you want {Singularity} to
+automatically bind mount `/dev` within the container. If set to
+'minimal', then only 'null', 'zero', 'random', 'urandom', and 'shm'
+will be included.
 
-``mount devpts``:
-This option determines if {Singularity} will mount a new instance of ``devpts``
-when there is a ``minimal`` ``/dev`` directory as explained above, or when the
-``--contain`` option is passed.
+``mount devpts``: This option determines if {Singularity} will mount a
+new instance of ``devpts`` when there is a ``minimal`` ``/dev``
+directory as explained above, or when the ``--contain`` option is
+passed.
 
-.. note::
-  This requires either a kernel configured with
-  ``CONFIG_DEVPTS_MULTIPLE_INSTANCES=y``, or a kernel version at or newer than
-  ``4.7``.
+.. note:: This requires either a kernel configured with
+  ``CONFIG_DEVPTS_MULTIPLE_INSTANCES=y``, or a kernel version at or
+  newer than ``4.7``.
 
-``mount home``:
-When this option is enabled, {Singularity} will automatically determine the
-calling user's home directory and attempt to mount it into the container.
+``mount home``: When this option is enabled, {Singularity} will
+automatically determine the calling user's home directory and attempt
+to mount it into the container.
 
-``mount tmp``:
-When this option is enabled, {Singularity} will automatically bind mount
-``/tmp`` and ``/var/tmp`` into the container from the host. If the
-``--contain`` option is passed, {Singularity} will create both locations within
-the ``sessiondir`` or within the directory specified by the ``--workdir``
-option if that is passed as well.
+``mount tmp``: When this option is enabled, {Singularity} will
+automatically bind mount ``/tmp`` and ``/var/tmp`` into the container
+from the host. If the ``--contain`` option is passed, {Singularity}
+will create both locations within the ``sessiondir`` or within the
+directory specified by the ``--workdir`` option if that is passed as
+well.
 
-``mount hostfs``:
-This option will cause {Singularity} to probe the host for all mounted
-filesystems and bind those into containers at runtime.
+``mount hostfs``: This option will cause {Singularity} to probe the
+host for all mounted filesystems and bind those into containers at
+runtime.
 
-``mount slave``:
-{Singularity} automatically mounts a handful host system directories to the
-container by default. This option determines if filesystem changes on the host
-should automatically be propogated to those directories in the container.
-
-.. note::
-  This should be set to ``yes`` when autofs mounts in the system should
-  show up in the container.
-
-``memory fs type``:
-This option allows admins to choose the temporary filesystem used by
-{Singularity}. Temporary filesystems are primarily used for system
-directories like ``/dev`` when the host system directory is not mounted
-within the container.
+``mount slave``: {Singularity} automatically mounts a handful host
+system directories to the container by default. This option determines
+if filesystem changes on the host should automatically be propogated
+to those directories in the container.
 
 .. note::
 
-  For Cray CLE 5 and 6, up to CLE 6.0.UP05, there is an issue (kernel panic) when Singularity
-  uses tmpfs, so on affected systems it's recommended to set this value to ramfs to avoid a
-  kernel panic
+  This should be set to ``yes`` when autofs mounts in the system
+  should show up in the container.
+
+``memory fs type``: This option allows admins to choose the temporary
+filesystem used by {Singularity}. Temporary filesystems are primarily
+used for system directories like ``/dev`` when the host system
+directory is not mounted within the container.
+
+.. note::
+
+  For Cray CLE 5 and 6, up to CLE 6.0.UP05, there is an issue (kernel
+  panic) when Singularity uses tmpfs, so on affected systems it's
+  recommended to set this value to ramfs to avoid a kernel panic
 
 Bind Mount Management
 =====================
 
-``bind path``:
-This option is used for defining a list of files or directories to
-automatically be made available when {Singularity} runs a container.
-In order to successfully mount listed paths the file or directory path must
-exist within the container, or {Singularity} has either overlay or underlay
-support enabled.
+``bind path``: This option is used for defining a list of files or
+directories to automatically be made available when {Singularity} runs
+a container.  In order to successfully mount listed paths the file or
+directory path must exist within the container, or {Singularity} has
+either overlay or underlay support enabled.
 
 .. note::
-  This option is ignored when containers are invoked with the ``--contain`` option.
 
-You can define the a bind point where the source and destination are identical:
+  This option is ignored when containers are invoked with the
+  ``--contain`` option.
+
+You can define the a bind point where the source and destination are
+identical:
 
 .. code-block:: none
 
@@ -201,54 +210,52 @@ Or you can specify different source and destination locations using:
   bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 
 
-``user bind control``:
-This allows admins to decide if users can define bind points at runtime.
-By Default, this option is set to ``YES``, which means users can specify bind
-points, scratch and tmp locations.
+``user bind control``: This allows admins to decide if users can
+define bind points at runtime.  By Default, this option is set to
+``YES``, which means users can specify bind points, scratch and tmp
+locations.
 
 Limiting Container Execution
 ============================
 
-There are several ways to limit container execution as an admin listed below.
-If stricter controls are required, check out the
+There are several ways to limit container execution as an admin listed
+below.  If stricter controls are required, check out the
 :ref:`Execution Control List <execution_control_list>`.
 
-``limit container owners``:
-This restricts container execution to only allow conatiners that are owned by
-the specified user.
+``limit container owners``: This restricts container execution to only
+allow conatiners that are owned by the specified user.
 
 .. note::
 
-  This feature will only apply when {Singularity} is running in SUID mode and the
-  user is non-root. By default this is set to `NULL`.
+  This feature will only apply when {Singularity} is running in SUID
+  mode and the user is non-root. By default this is set to `NULL`.
 
-``limit container groups``:
-This restricts container execution to only allow conatiners that are owned by
-the specified group.
-
-.. note::
-
-  This feature will only apply when {Singularity} is running in SUID mode and the
-  user is non-root. By default this is set to `NULL`.
-
-``limit container paths``:
-This restricts container execution to only allow containers that are located
-within the specified path prefix.
+``limit container groups``: This restricts container execution to only
+allow conatiners that are owned by the specified group.
 
 .. note::
 
-  This feature will only apply when {Singularity} is running in SUID mode and the
-  user is non-root. By default this is set to `NULL`.
+  This feature will only apply when {Singularity} is running in SUID
+  mode and the user is non-root. By default this is set to `NULL`.
 
-``allow container ${type}``:
-This option allows admins to limit the types of image formats that can be
-leveraged by users with {Singularity}. Formats include ``squashfs`` which is used
-by SIF and v2.x Singularity images, ``extfs`` which is used for writable
-overlays and some legacy Singularity images, ``dir`` which is used by sandbox
-images and ``encrypted`` which is only used by SIF images to encrypt filesystem
-contents.
+``limit container paths``: This restricts container execution to only
+allow containers that are located within the specified path prefix.
 
 .. note::
+
+  This feature will only apply when {Singularity} is running in SUID
+  mode and the user is non-root. By default this is set to `NULL`.
+
+``allow container ${type}``: This option allows admins to limit the
+types of image formats that can be leveraged by users with
+{Singularity}. Formats include ``squashfs`` which is used by SIF and
+v2.x Singularity images, ``extfs`` which is used for writable overlays
+and some legacy Singularity images, ``dir`` which is used by sandbox
+images and ``encrypted`` which is only used by SIF images to encrypt
+filesystem contents.
+
+.. note::
+
   These limitations do not apply to the root user.
 
 Networking Options
@@ -265,74 +272,74 @@ configurations may disrupt the host networking environment.
 ability to run containers with adminstrator specified CNI
 configurations.
 
-``allow net users``:
-Allow specified root administered CNI network configurations to be used by the
-specified list of users. By default only root may use CNI configuration,
-except in the case of a fakeroot execution where only 40_fakeroot.conflist
-is used. This feature only applies when {Singularity} is running in
-SUID mode and the user is non-root.
+``allow net users``: Allow specified root administered CNI network
+configurations to be used by the specified list of users. By default
+only root may use CNI configuration, except in the case of a fakeroot
+execution where only 40_fakeroot.conflist is used. This feature only
+applies when {Singularity} is running in SUID mode and the user is
+non-root.
 
-``allow net groups``:
-Allow specified root administered CNI network configurations to be used by the
-specified list of users. By default only root may use CNI configuration,
-except in the case of a fakeroot execution where only 40_fakeroot.conflist
-is used. This feature only applies when {Singularity} is running in
-SUID mode and the user is non-root.
+``allow net groups``: Allow specified root administered CNI network
+configurations to be used by the specified list of users. By default
+only root may use CNI configuration, except in the case of a fakeroot
+execution where only 40_fakeroot.conflist is used. This feature only
+applies when {Singularity} is running in SUID mode and the user is
+non-root.
 
-``allow net networks``:
-Specify the names of CNI network configurations that may be used by users and
-groups listed in the allow net users / allow net groups directives. Thus feature
-only applies when {Singularity} is running in SUID mode and the user is non-root.
+``allow net networks``: Specify the names of CNI network
+configurations that may be used by users and groups listed in the
+allow net users / allow net groups directives. Thus feature only
+applies when {Singularity} is running in SUID mode and the user is
+non-root.
 
 
 GPU Options
 ===========
 
-{Singularity} provides integration with GPUs in order to facilitate GPU based
-workloads seamlessly. Both options listed below are particularly useful in
-GPU only environments. For more information on using GPUs with Singularity
-checkout :ref:`GPU Library Configuration <gpu_library_configuration>`.
+{Singularity} provides integration with GPUs in order to facilitate
+GPU based workloads seamlessly. Both options listed below are
+particularly useful in GPU only environments. For more information on
+using GPUs with Singularity checkout :ref:`GPU Library Configuration
+<gpu_library_configuration>`.
 
-``always use nv``:
-Enabling this option will cause every action command
-(``exec/shell/run/instance``) to be executed with the ``--nv`` option
-implicitly added.
+``always use nv``: Enabling this option will cause every action
+command (``exec/shell/run/instance``) to be executed with the ``--nv``
+option implicitly added.
 
-``always use rocm``:
-Enabling this option will cause every action command
-(``exec/shell/run/instance``) to be executed with the ``--rocm`` option
-implicitly added.
+``always use rocm``: Enabling this option will cause every action
+command (``exec/shell/run/instance``) to be executed with the
+``--rocm`` option implicitly added.
 
 Supplemental Filesystems
 ========================
 
-``enable fusemount``:
-This will allow users to mount fuse filesystems inside containers using the
-``--fusemount`` flag.
+``enable fusemount``: This will allow users to mount fuse filesystems
+inside containers using the ``--fusemount`` flag.
 
-``enable overlay``:
-This option will allow {Singularity} to create bind mounts at paths that do not
-exist within the container image. This option can be set to ``try``, which will
-try to use an overlayfs. If it fails to create an overlayfs in this case the
-bind path will be silently ignored.
+``enable overlay``: This option will allow {Singularity} to create
+bind mounts at paths that do not exist within the container
+image. This option can be set to ``try``, which will try to use an
+overlayfs. If it fails to create an overlayfs in this case the bind
+path will be silently ignored.
 
-``enable underlay``:
-This option will allow {Singularity} to create bind mounts at paths that do not
-exist within the container image, just like ``enable overlay``, but instead
-using an underlay. This is suitable for systems where overlay is not possible
-or not working. If the overlay option is available and working, it will be
-used instead.
+``enable underlay``: This option will allow {Singularity} to create
+bind mounts at paths that do not exist within the container image,
+just like ``enable overlay``, but instead using an underlay. This is
+suitable for systems where overlay is not possible or not working. If
+the overlay option is available and working, it will be used instead.
 
 CNI Configuration and Plugins
 =============================
 
-``cni configuration path``:
-This option allows admins to specify a custom path for the CNI configuration
-that {Singularity} will use for `Network Virtualization <\{userdocs\}/networking.html>`_.
+``cni configuration path``: This option allows admins to specify a
+custom path for the CNI configuration that {Singularity} will use for
+`Network Virtualization
+<\{userdocs\}/networking.html>`_.
 
-``cni plugin path``:
-This option allows admins to specify a custom path for {Singularity} to access
-CNI plugin executables. Check out the `Network Virtualization <\{userdocs\}/networking.html>`_
+``cni plugin path``: This option allows admins to specify a custom
+path for {Singularity} to access CNI plugin executables. Check out the
+`Network Virtualization
+<\{userdocs\}/networking.html>`_
 section of the user guide for more information.
 
 External Binaries
@@ -381,18 +388,19 @@ extract SIF and SquashFS containers.
 Updating Configuration Options
 ==============================
 
-In order to manage this configuration file, {Singularity} has a ``config global``
-command group that allows you to get, set, reset, and unset values through the
-CLI. It's important to note that these commands must be run with elevated
-priveledges because the ``singularity.conf`` can only be modified by an
-administrator.
+In order to manage this configuration file, {Singularity} has a
+``config global`` command group that allows you to get, set, reset,
+and unset values through the
+CLI. It's important to note that these commands must be run with
+elevated priveledges because the ``singularity.conf`` can only be
+modified by an administrator.
 
 Example
 -------
 
-In this example we will changing the ``bind path`` option described above.
-First we can see the current list of bind paths set within our system
-configuration:
+In this example we will changing the ``bind path`` option described
+above.  First we can see the current list of bind paths set within our
+system configuration:
 
 .. code-block:: none
 
@@ -415,8 +423,8 @@ From here we can remove a path with:
   $ sudo singularity config global --get "bind path"
   /etc/resolv.conf,/etc/hosts
 
-If we want to reset the option to the default at installation, then we can
-reset it with:
+If we want to reset the option to the default at installation, then we
+can reset it with:
 
 .. code-block:: none
 
@@ -424,11 +432,12 @@ reset it with:
   $ sudo singularity config global --get "bind path"
   /etc/localtime,/etc/hosts
 
-And now we are back to our original option settings. You can also test what a
-change would look like by using the ``--dry-run`` option in conjunction with
-the above commands. Instead of writing to the configuration file, it will
-output what would have been written to the configuration file if the command
-had been run without the ``--dry-run`` option:
+And now we are back to our original option settings. You can also test
+what a change would look like by using the ``--dry-run`` option in
+conjunction with the above commands. Instead of writing to the
+configuration file, it will output what would have been written to the
+configuration file if the command had been run without the
+``--dry-run`` option:
 
 .. code-block:: none
 
@@ -450,9 +459,9 @@ had been run without the ``--dry-run`` option:
   $ sudo singularity config global --get "bind path"
   /etc/localtime,/etc/hosts
 
-Above we can see that ``/etc/resolv.conf`` is listed as a bind path in the
-output of the ``--dry-run`` command, but did not affect the actual bind paths
-of the system.
+Above we can see that ``/etc/resolv.conf`` is listed as a bind path in
+the output of the ``--dry-run`` command, but did not affect the actual
+bind paths of the system.
 
 ------------
 cgroups.toml
@@ -552,28 +561,29 @@ specified in the ``[cpu]`` section of the TOML file.
 
 **shares**
 
-This corresponds to a ratio versus other cgroups with cpu shares. Usually the
-default value is ``1024``. That means if you want to allow to use 50% of a
-single CPU, you will set ``512`` as value.
+This corresponds to a ratio versus other cgroups with cpu
+shares. Usually the default value is ``1024``. That means if you want
+to allow to use 50% of a single CPU, you will set ``512`` as value.
 
 .. code-block:: none
 
   [cpu]
       shares = 512
 
-A cgroup can get more than its share of CPU if there are enough idle CPU cycles
-available in the system, due to the work conserving nature of the scheduler, so
-a contained process can consume all CPU cycles even with a ratio of 50%. The
-ratio is only applied when two or more processes conflicts with their needs of
-CPU cycles.
+A cgroup can get more than its share of CPU if there are enough idle
+CPU cycles available in the system, due to the work conserving nature
+of the scheduler, so a contained process can consume all CPU cycles
+even with a ratio of 50%. The ratio is only applied when two or more
+processes conflicts with their needs of CPU cycles.
 
 **quota/period**
 
 You can enforce hard limits on the CPU cycles a cgroup can consume, so
-contained processes can't use more than the amount of CPU time set for the
-cgroup. ``quota`` allows you to configure the amount of CPU time that a cgroup
-can use per period. The default is 100ms (100000us). So if you want to limit
-amount of CPU time to 20ms during period of 100ms:
+contained processes can't use more than the amount of CPU time set for
+the cgroup. ``quota`` allows you to configure the amount of CPU time
+that a cgroup can use per period. The default is 100ms (100000us). So
+if you want to limit amount of CPU time to 20ms during period of
+100ms:
 
 .. code-block:: none
 
@@ -611,14 +621,15 @@ use the ``[blockIO]`` section of the TOML file:
       weight = 1000
       leafWeight = 1000
 
-``weight`` and ``leafWeight`` accept values between ``10`` and ``1000``.
+``weight`` and ``leafWeight`` accept values between ``10`` and
+``1000``.
 
-``weight`` is the default weight of the group on all the devices until and
-unless overridden by a per device rule.
+``weight`` is the default weight of the group on all the devices until
+and unless overridden by a per device rule.
 
-``leafWeight`` relates to weight for the purpose of deciding how heavily to
-weigh tasks in the given cgroup while competing with the cgroup's child
-cgroups.
+``leafWeight`` relates to weight for the purpose of deciding how
+heavily to weigh tasks in the given cgroup while competing with the
+cgroup's child cgroups.
 
 
 To apply limits to specific block devices, you must set configuration
@@ -695,18 +706,19 @@ filesystem and by checking against a list of signing entities.
     dirpath = "/tmp/containers"
     keyfp = ["7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
 
-Only the containers running from and signed with above-mentioned path and keys
-will be authorized to run.
+Only the containers running from and signed with above-mentioned path
+and keys will be authorized to run.
 
 Three possible list modes you can choose from:
 
-**Whitestrict**: The SIF must be signed by *ALL* of the keys mentioned.
+**Whitestrict**: The SIF must be signed by *ALL* of the keys
+ mentioned.
 
-**Whitelist**: As long as the SIF is signed by one or more of the keys, the
-container is allowed to run.
+**Whitelist**: As long as the SIF is signed by one or more of the
+keys, the container is allowed to run.
 
-**Blacklist**: Only the containers whose keys are not mentioned in the group
-are allowed to run.
+**Blacklist**: Only the containers whose keys are not mentioned in the
+group are allowed to run.
 
 .. note::
 
@@ -720,11 +732,12 @@ are allowed to run.
 Managing ECL public keys
 ========================
 
-In {Singularity} 3.6, public keys associated with fingerprints specified in ECL rules
-were required to be present in user's local keyring which is not very
-convenient. {Singularity} 3.7.0 provides a mechanism to administrators for managing
-a global keyring that ECL uses during signature verification, for that purpose a
-``--global`` option was added for:
+In {Singularity} 3.6, public keys associated with fingerprints
+specified in ECL rules were required to be present in user's local
+keyring which is not very convenient. {Singularity} 3.7.0 provides a
+mechanism to administrators for managing a global keyring that ECL
+uses during signature verification, for that purpose a ``--global``
+option was added for:
 
   * ``singularity key import`` (root user only)
   * ``singularity key pull`` (root user only)
@@ -733,9 +746,11 @@ a global keyring that ECL uses during signature verification, for that purpose a
   * ``singularity key list``
 
 .. note::
+
     For security reasons, it is not possible to import private keys
     into this global keyring because it must be accessible by users
-    and is stored in the file ``SYSCONFDIR/singularity/global-pgp-public``.
+    and is stored in the file
+    ``SYSCONFDIR/singularity/global-pgp-public``.
 
 .. _gpu_library_configuration:
 
@@ -743,12 +758,12 @@ a global keyring that ECL uses during signature verification, for that purpose a
 GPU Library Configuration
 -------------------------
 
-When a container includes a GPU enabled application, {Singularity} (with
-the ``--nv`` or ``--rocm`` options) can properly inject the required
-Nvidia or AMD GPU driver libraries into the container, to match the
-host's kernel. The GPU ``/dev`` entries are provided in containers run
-with ``--nv`` or ``--rocm`` even if the ``--contain`` option is used
-to restrict the in-container device tree.
+When a container includes a GPU enabled application, {Singularity}
+(with the ``--nv`` or ``--rocm`` options) can properly inject the
+required Nvidia or AMD GPU driver libraries into the container, to
+match the host's kernel. The GPU ``/dev`` entries are provided in
+containers run with ``--nv`` or ``--rocm`` even if the ``--contain``
+option is used to restrict the in-container device tree.
 
 Compatibility between containerized CUDA/ROCm/OpenCL applications and
 host drivers/libraries is dependent on the versions of the GPU compute
@@ -761,13 +776,13 @@ usage information is discussed in the `GPU Support` section of the
 NVIDIA GPUs / CUDA
 ==================
 
-The ``nvliblist.conf`` configuration file is used to
-specify libraries and executables that need to be injected into the
-container when running {Singularity} with the ``--nv`` Nvidia GPU
-support option. The provided ``nvliblist.conf`` is suitable for CUDA
-11, but may need to be modified if you need to include additional
-libraries, or further libraries are added to newer versions of the
-Nvidia driver/CUDA distribution.
+The ``nvliblist.conf`` configuration file is used to specify libraries
+and executables that need to be injected into the container when
+running {Singularity} with the ``--nv`` Nvidia GPU support option. The
+provided ``nvliblist.conf`` is suitable for CUDA 11, but may need to
+be modified if you need to include additional libraries, or further
+libraries are added to newer versions of the Nvidia driver/CUDA
+distribution.
 
 When adding new entries to ``nvliblist.conf`` use the bare filename of
 executables, and the ``xxxx.so`` form of libraries. Libraries are
@@ -811,10 +826,10 @@ AMD Radeon GPUs / ROCm
 
 The ``rocmliblist.conf`` file is used to specify libraries and
 executables that need to be injected into the container when running
-{Singularity} with the ``--rocm`` Radeon GPU support option. The provided
-``rocmliblist.conf`` is suitable for ROCm 4.0, but may need to modified
-if you need to include additional libraries, or further libraries are
-added to newer versions of the ROCm distribution.
+{Singularity} with the ``--rocm`` Radeon GPU support option. The
+provided ``rocmliblist.conf`` is suitable for ROCm 4.0, but may need
+to modified if you need to include additional libraries, or further
+libraries are added to newer versions of the ROCm distribution.
 
 When adding new entries to ``rocmlist.conf`` use the bare filename of
 executables, and the ``xxxx.so`` form of libraries. Libraries are
@@ -857,28 +872,31 @@ configured in ``/etc/ld.so.conf`` (libraries).
 capability.json
 ---------------
 
-.. note::
-     It is extremely important to recognize that **granting users Linux
-     capabilities with the** ``capability`` **command group is usually identical
-     to granting those users root level access on the host system**. Most if not
-     all capabilities will allow users to "break out" of the container and
-     become root on the host. This feature is targeted toward special use cases
-     (like cloud-native architectures) where an admin/developer might want to
-     limit the attack surface within a container that normally runs as root.
-     This is not a good option in multi-tenant HPC environments where an admin
-     wants to grant a user special privileges within a container. For that and
-     similar use cases, the :ref:`fakeroot feature <fakeroot>` is a better
-     option.
+.. warning::
 
-{Singularity} provides full support for admins to grant and revoke Linux
-capabilities on a user or group basis. The ``capability.json`` file is
-maintained by {Singularity} in order to manage these capabilities. The
-``capability`` command group allows you to ``add``, ``drop``, and ``list``
-capabilities for users and groups.
+     It is extremely important to recognize that **granting users
+     Linux capabilities with the** ``capability`` **command group is
+     usually identical to granting those users root level access on
+     the host system**. Most if not all capabilities will allow users
+     to "break out" of the container and become root on the host. This
+     feature is targeted toward special use cases (like cloud-native
+     architectures) where an admin/developer might want to limit the
+     attack surface within a container that normally runs as root.
+     This is not a good option in multi-tenant HPC environments where
+     an admin wants to grant a user special privileges within a
+     container. For that and similar use cases, the :ref:`fakeroot
+     feature <fakeroot>` is a better option.
 
-For example, let us suppose that we have decided to grant a user (named
-``pinger``) capabilities to open raw sockets so that they can use ``ping`` in
-a container where the binary is controlled via capabilities.
+{Singularity} provides full support for admins to grant and revoke
+Linux capabilities on a user or group basis. The ``capability.json``
+file is maintained by {Singularity} in order to manage these
+capabilities. The ``capability`` command group allows you to ``add``,
+``drop``, and ``list`` capabilities for users and groups.
+
+For example, let us suppose that we have decided to grant a user
+(named ``pinger``) capabilities to open raw sockets so that they can
+use ``ping`` in a container where the binary is controlled via
+capabilities.
 
 To do so, we would issue a command such as this:
 
@@ -886,24 +904,27 @@ To do so, we would issue a command such as this:
 
     $ sudo singularity capability add --user pinger CAP_NET_RAW
 
-This means the user ``pinger`` has just been granted permissions (through Linux
-capabilities) to open raw sockets within {Singularity} containers.
+This means the user ``pinger`` has just been granted permissions
+(through Linux capabilities) to open raw sockets within {Singularity}
+containers.
 
-We can check that this change is in effect with the ``capability list``
-command.
+We can check that this change is in effect with the ``capability
+list`` command.
 
 .. code-block:: none
 
     $ sudo singularity capability list --user pinger
     CAP_NET_RAW
 
-To take advantage of this new capability, the user ``pinger`` must also request
-the capability when executing a container with the ``--add-caps`` flag.
-``pinger`` would need to run a command like this:
+To take advantage of this new capability, the user ``pinger`` must
+also request the capability when executing a container with the
+``--add-caps`` flag.  ``pinger`` would need to run a command like
+this:
 
 .. code-block:: none
 
-    $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+    $ singularity exec --add-caps CAP_NET_RAW \
+      library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
     64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
 
@@ -911,52 +932,57 @@ the capability when executing a container with the ``--add-caps`` flag.
     1 packets transmitted, 1 received, 0% packet loss, time 0ms
     rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
 
-If we decide that it is no longer necessary to allow the user ``pinger``
-to open raw sockets within {Singularity} containers, we can revoke the
-appropriate Linux capability like so:
+If we decide that it is no longer necessary to allow the user
+``pinger`` to open raw sockets within {Singularity} containers, we can
+revoke the appropriate Linux capability like so:
 
 .. code-block:: none
 
     $ sudo singularity capability drop --user pinger CAP_NET_RAW
 
-Now if ``pinger`` tries to use ``CAP_NET_RAW``, {Singularity} will not give the
-capability to the container and ``ping`` will fail to create a socket:
+Now if ``pinger`` tries to use ``CAP_NET_RAW``, {Singularity} will not
+give the capability to the container and ``ping`` will fail to create
+a socket:
 
 .. code-block:: none
 
-    $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+    $ singularity exec --add-caps CAP_NET_RAW \
+      library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     WARNING: not authorized to add capability: CAP_NET_RAW
     ping: socket: Operation not permitted
 
-The ``capability add`` and ``drop`` subcommands will also accept the case
-insensitive keyword ``all`` to grant or revoke all Linux capabilities to a user
-or group.
+The ``capability add`` and ``drop`` subcommands will also accept the
+case insensitive keyword ``all`` to grant or revoke all Linux
+capabilities to a user or group.
 
 For more information about individual Linux capabilities check out the
-`man pages <http://man7.org/linux/man-pages/man7/capabilities.7.html>`_ or
-use the ``capability avail`` command to output available capabilities with a
-description of their behaviors.
+`man pages
+<http://man7.org/linux/man-pages/man7/capabilities.7.html>`_ or use
+the ``capability avail`` command to output available capabilities with
+a description of their behaviors.
 
 ----------------
 seccomp-profiles
 ----------------
 
-Secure Computing (seccomp) Mode is a feature of the Linux kernel that allows an
-administrator to filter system calls being made from a container. Profiles made
-up of allowed and restricted calls can be passed to different containers.
-*Seccomp* provides more control than *capabilities* alone, giving a smaller
-attack surface for an attacker to work from within a container.
+Secure Computing (seccomp) Mode is a feature of the Linux kernel that
+allows an administrator to filter system calls being made from a
+container. Profiles made up of allowed and restricted calls can be
+passed to different containers.  *Seccomp* provides more control than
+*capabilities* alone, giving a smaller attack surface for an attacker
+to work from within a container.
 
-You can set the default action with ``defaultAction`` for a non-listed system
-call. Example: ``SCMP_ACT_ALLOW`` filter will allow all the system calls if it
-matches the filter rule and you can set it to ``SCMP_ACT_ERRNO`` which will have
-the thread receive a return value of *errno* if it calls a system call that matches
-the filter rule.
-The file is formatted in a way that it can take a list of additional system calls
-for different architecture and {Singularity} will automatically take syscalls
-related to the current architecture where it's been executed.
-The ``include``/``exclude``-> ``caps`` section will include/exclude the listed
-system calls if the user has the associated capability.
+You can set the default action with ``defaultAction`` for a non-listed
+system call. Example: ``SCMP_ACT_ALLOW`` filter will allow all the
+system calls if it matches the filter rule and you can set it to
+``SCMP_ACT_ERRNO`` which will have the thread receive a return value
+of *errno* if it calls a system call that matches the filter rule.
+The file is formatted in a way that it can take a list of additional
+system calls for different architecture and {Singularity} will
+automatically take syscalls related to the current architecture where
+it's been executed.  The ``include``/``exclude``-> ``caps`` section
+will include/exclude the listed system calls if the user has the
+associated capability.
 
 Use the ``--security`` option to invoke the container like:
 
@@ -964,18 +990,20 @@ Use the ``--security`` option to invoke the container like:
 
   $ sudo singularity shell --security seccomp:/home/david/my.json my_container.sif
 
-For more insight into security options, network options, cgroups, capabilities,
-etc, please check the `Userdocs <\{userdocs\}>`_
-and it's `Appendix <\{userdocs\}/appendix.html>`_.
+For more insight into security options, network options, cgroups,
+capabilities, etc, please check the `Userdocs
+<\{userdocs\}>`_ and it's
+`Appendix
+<\{userdocs\}/appendix.html>`_.
 
 ------------
 remote.yaml
 ------------
 
-System-wide remote endpoints are defined in a configuration file typically
-located at ``/usr/local/etc/singularity/remote.yaml`` (this location may
-vary depending on installation parameters) and can be managed by
-administrators with the ``remote`` command group.
+System-wide remote endpoints are defined in a configuration file
+typically located at ``/usr/local/etc/singularity/remote.yaml`` (this
+location may vary depending on installation parameters) and can be
+managed by administrators with the ``remote`` command group.
 
 Remote Endpoints
 ================
@@ -987,10 +1015,11 @@ Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/library/guide#create>`_ their container
 images with others.
 
-{Singularity} allows users to login to an account on the Sylabs Cloud, or
-configure {Singularity} to use an API compatable container service such as
-a local installation of {Singularity} Enterprise, which provides an on-premise
-private Container Library, Remote Builder and Key Store.
+{Singularity} allows users to login to an account on the Sylabs Cloud,
+or configure {Singularity} to use an API compatable container service
+such as a local installation of {Singularity} Enterprise, which
+provides an on-premise private Container Library, Remote Builder and
+Key Store.
 
 .. note::
 
@@ -1001,8 +1030,8 @@ private Container Library, Remote Builder and Key Store.
 **Examples**
 
 
-Use the ``remote`` command group with the ``--global`` flag to create a
-system-wide remote endpoint:
+Use the ``remote`` command group with the ``--global`` flag to create
+a system-wide remote endpoint:
 
 .. code-block:: none
 
@@ -1019,16 +1048,18 @@ Conversely, to remove a system-wide endpoint:
 
 .. note::
 
-   Once users log in to a system wide endpoint, a copy of the endpoint will be listed in
-   a their ``~/.singularity/remote.yaml`` file. This means modifications or removal of
-   the system-wide endpoint will not be reflected in the users configuration unless they
-   remove the endpoint themselves.
+   Once users log in to a system wide endpoint, a copy of the endpoint
+   will be listed in a their ``~/.singularity/remote.yaml`` file. This
+   means modifications or removal of the system-wide endpoint will not
+   be reflected in the users configuration unless they remove the
+   endpoint themselves.
 
 Exclusive Endpoint
 ------------------
 
-{Singularity} 3.7 introduces the ability for an administrator to make a remote
-the only usable remote for the system by using the ``--exclusive`` flag:
+{Singularity} 3.7 introduces the ability for an administrator to make
+a remote the only usable remote for the system by using the
+``--exclusive`` flag:
 
 .. code-block:: none
 
@@ -1065,8 +1096,8 @@ be added by specifying the ``--insecure`` flag:
    INFO:    Global option detected. Will not automatically log into remote.
 
 This flag controls HTTP vs HTTPS for service discovery only. The
-protocol used to access individual library, build and keyservice URLs is
-set by the service discovery file.
+protocol used to access individual library, build and keyservice URLs
+is set by the service discovery file.
 
 Additional Information
 ----------------------
@@ -1078,11 +1109,12 @@ endpoints, please check the `Remote Userdocs
 Keyserver Configuration
 =======================
 
-By default, {Singularity} will use the keyserver correlated to the active cloud
-service endpoint. This behavior can be changed or supplemented via the
-``add-keyserver`` and ``remove-keyserver`` commands. These commands allow an
-administrator to create a global list of key servers used to verify container
-signatures by default.
+By default, {Singularity} will use the keyserver correlated to the
+active cloud service endpoint. This behavior can be changed or
+supplemented via the ``add-keyserver`` and ``remove-keyserver``
+commands. These commands allow an administrator to create a global
+list of key servers used to verify container signatures by default.
 
-For more details on the ``remote`` command group and managing keyservers,
-please check the `Remote Userdocs <\{userdocs\}/endpoint.html>`_.
+For more details on the ``remote`` command group and managing
+keyservers, please check the `Remote Userdocs
+<\{userdocs\}/endpoint.html>`_.

--- a/installation.rst
+++ b/installation.rst
@@ -5,9 +5,10 @@ Installing {Singularity}
 ########################
 
 This section will guide you through the process of installing
-{Singularity} {InstallationVersion} via several different methods. (For
-instructions on installing earlier versions of {Singularity} please see
-`earlier versions of the docs <https://singularity.hpcng.org/docs/>`_.)
+{Singularity} {InstallationVersion} via several different
+methods. (For instructions on installing earlier versions of
+{Singularity} please see `earlier versions of the docs
+<https://singularity.hpcng.org/docs/>`_.)
 
 =====================
 Installation on Linux
@@ -202,8 +203,8 @@ The directory used for ``SINGULARITY_CACHEDIR`` should be:
  - A unique location for each user. Permissions are set on the cache
    so that private images cached for one user are not exposed to
    another. This means that ``SINGULARITY_CACHEDIR`` cannot be shared.
- - Located on a filesystem with sufficient space for the number and size of
-   container images anticipated.
+ - Located on a filesystem with sufficient space for the number and
+   size of container images anticipated.
  - Located on a filesystem that supports atomic rename, if possible.
 
 In {Singularity} version 3.6 and above the cache is concurrency safe.
@@ -219,9 +220,9 @@ atomic to a single client, not across systems accessing the same NFS
 share.
 
 If you are not certain that your ``$HOME`` or ``SINGULARITY_CACHEDIR``
-filesytems support atomic rename, do not run ``singularity`` in parallel
-using remote container URLs. Instead use ``singularity pull`` to
-create a local SIF image, and then run this SIF image in a parallel
+filesytems support atomic rename, do not run ``singularity`` in
+parallel using remote container URLs. Instead use ``singularity pull``
+to create a local SIF image, and then run this SIF image in a parallel
 step. An alternative is to use the ``--disable-cache`` option, but
 this will result in each {Singularity} instance independently fetching
 the container from the remote source, into a temporary location.
@@ -230,8 +231,8 @@ the container from the remote source, into a temporary location.
 NFS
 ---
 
-NFS filesystems support overlay mounts as a ``lowerdir`` only, and do not
-support user-namespace (sub)uid/gid mapping.
+NFS filesystems support overlay mounts as a ``lowerdir`` only, and do
+not support user-namespace (sub)uid/gid mapping.
 
  - Containers run from SIF files located on an NFS filesystem do not
    have restrictions.
@@ -279,15 +280,16 @@ dependencies and install `Go <https://golang.org/>`_.
 Install from Source
 -------------------
 
-To use the latest version of {Singularity} from GitHub you will need to
-build and install it from source. This may sound daunting, but the
+To use the latest version of {Singularity} from GitHub you will need
+to build and install it from source. This may sound daunting, but the
 process is straightforward, and detailed below:
 
 
 Install Dependencies
 ====================
 
-On Red Hat Enterprise Linux or CentOS install the following dependencies:
+On Red Hat Enterprise Linux or CentOS install the following
+dependencies:
 
 .. code-block:: sh
 
@@ -319,8 +321,9 @@ On Ubuntu or Debian install the following dependencies:
 
 .. note::
 
-   You can build {Singularity} (3.5+) without ``cryptsetup`` available, but will
-   not be able to use encrypted containers without it installed on your system.
+   You can build {Singularity} (3.5+) without ``cryptsetup``
+   available, but will not be able to use encrypted containers without
+   it installed on your system.
 
 .. _install-go:
 
@@ -344,10 +347,10 @@ This is one of several ways to `install and configure Go
    versions.
 
 
-Visit the `Go download page <https://golang.org/dl/>`_ and pick a package
-archive to download. Copy the link address and download with wget.  Then extract
-the archive to ``/usr/local`` (or use other instructions on go installation
-page).
+Visit the `Go download page <https://golang.org/dl/>`_ and pick a
+package archive to download. Copy the link address and download with
+wget.  Then extract the archive to ``/usr/local`` (or use other
+instructions on go installation page).
 
 .. code-block:: none
 
@@ -383,8 +386,8 @@ with the installation.
 Checkout Code from Git
 ======================
 
-The following commands will install {Singularity} from the `GitHub repo
-<https://github.com/hpcng/singularity>`_ to ``/usr/local``. This
+The following commands will install {Singularity} from the `GitHub
+repo <https://github.com/hpcng/singularity>`_ to ``/usr/local``. This
 method will work for >=v{InstallationVersion}. To install an older
 tagged release see `older versions of the docs
 <https://singularity.hpcng.org/docs/>`_.
@@ -476,8 +479,8 @@ building {Singularity} from source.
 Unprivileged (non-setuid) Installation
 ======================================
 
-If you need to install {Singularity} as a non-root user, or do not wish
-to allow the use of a setuid root binary, you can configure
+If you need to install {Singularity} as a non-root user, or do not
+wish to allow the use of a setuid root binary, you can configure
 {Singularity} with the ``--without-suid`` option to mconfig:
 
 .. code-block:: none
@@ -491,8 +494,8 @@ flow by setting the option ``allow setuid = no`` in
 ``etc/singularity/singularity.conf`` within your installation
 directory.
 
-When {Singularity} does not use setuid all container execution will use
-a user namespace. This requires support from your operating system
+When {Singularity} does not use setuid all container execution will
+use a user namespace. This requires support from your operating system
 kernel, and imposes some limitations on functionality. You should
 review the :ref:`requirements <userns-requirements>` and
 :ref:`limitations <userns-limitations>` in the :ref:`user namespace
@@ -513,16 +516,16 @@ security.
 Source bash completion file
 ===========================
 
-To enjoy bash shell completion with {Singularity} commands and options,
-source the bash completion file:
+To enjoy bash shell completion with {Singularity} commands and
+options, source the bash completion file:
 
 .. code-block:: none
 
     $ . /usr/local/etc/bash_completion.d/singularity
 
 Add this command to your `~/.bashrc` file so that bash completion
-continues to work in new shells.  (Adjust the path if you
-installed {Singularity} to a different location.)
+continues to work in new shells.  (Adjust the path if you installed
+{Singularity} to a different location.)
 
 .. _install-rpm:
 
@@ -582,8 +585,8 @@ Build an RPM from Git source
 ============================
 
 Alternatively, to build an RPM from a branch of the Git repository you
-can clone the repository, directly ``make`` an rpm, and use it to install
-Singularity:
+can clone the repository, directly ``make`` an rpm, and use it to
+install Singularity:
 
 .. code-block:: none
 
@@ -624,8 +627,8 @@ directories to completely remove {Singularity}.
         /usr/local/bin/run-singularity \
         /usr/local/etc/bash_completion.d/singularity
 
-If you anticipate needing to remove {Singularity}, it might be easier to
-install it in a custom directory using the ``--prefix`` option to
+If you anticipate needing to remove {Singularity}, it might be easier
+to install it in a custom directory using the ``--prefix`` option to
 ``mconfig``.  In that case {Singularity} can be uninstalled simply by
 deleting the parent directory. Or it may be useful to install
 {Singularity} :ref:`using a package manager <install-rpm>` so that it
@@ -713,16 +716,15 @@ targets from the ``builddir`` directory in the source tree:
     and ``nc`` in order to test docker and instance/networking
     functionality.
 
-    {Singularity} must be installed in order to run the full
-    test suite, as it must run the CLI with setuid privilege for the
+    {Singularity} must be installed in order to run the full test
+    suite, as it must run the CLI with setuid privilege for the
     ``starter-suid`` binary.
 
 .. warning::
 
     ``sudo`` privilege is required to run the full tests, and you
     should not run the tests on a production system. We recommend
-    running the tests in an isolated development or build
-    environment.
+    running the tests in an isolated development or build environment.
 
 ==============================
 Installation on Windows or Mac
@@ -731,12 +733,12 @@ Installation on Windows or Mac
 Linux container runtimes like {Singularity} cannot run natively on
 Windows or Mac because of basic incompatibilities with the host
 kernel. (Contrary to a popular misconception, MacOS does not run on a
-Linux kernel. It runs on a kernel called Darwin originally forked
-from BSD.)
+Linux kernel. It runs on a kernel called Darwin originally forked from
+BSD.)
 
-For this reason, the {Singularity} community maintains a set of Vagrant
-Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one of
-`Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
+For this reason, the {Singularity} community maintains a set of
+Vagrant Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one
+of `Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
 source tools. The current versions can be found under the `sylabs
 <https://app.vagrantup.com/sylabs>`_ organization.
 
@@ -755,8 +757,8 @@ Install the following programs:
 Mac
 ---
 
-Singularity is available via Vagrant (installable with
-`Homebrew <https://brew.sh>`_ or manually)
+Singularity is available via Vagrant (installable with `Homebrew
+<https://brew.sh>`_ or manually)
 
 To use Vagrant via Homebrew:
 
@@ -777,16 +779,17 @@ directory to be used with your Vagrant VM.
     $ mkdir vm-singularity && \
         cd vm-singularity
 
-If you have already created and used this folder for another VM, you will need
-to destroy the VM and delete the Vagrantfile.
+If you have already created and used this folder for another VM, you
+will need to destroy the VM and delete the Vagrantfile.
 
 .. code-block:: none
 
     $ vagrant destroy && \
         rm Vagrantfile
 
-Then issue the following commands to bring up the Virtual Machine. (Substitute a
-different value for the ``$VM`` variable if you like.)
+Then issue the following commands to bring up the Virtual
+Machine. (Substitute a different value for the ``$VM`` variable if you
+like.)
 
 .. code-block:: none
 
@@ -795,7 +798,8 @@ different value for the ``$VM`` variable if you like.)
         vagrant up && \
         vagrant ssh
 
-You can check the installed version of {Singularity} with the following:
+You can check the installed version of {Singularity} with the
+following:
 
 .. code-block:: none
 
@@ -803,15 +807,17 @@ You can check the installed version of {Singularity} with the following:
     {InstallationVersion}
 
 
-Of course, you can also start with a plain OS Vagrant box as a base and then
-install {Singularity} using one of the above methods for Linux.
+Of course, you can also start with a plain OS Vagrant box as a base
+and then install {Singularity} using one of the above methods for
+Linux.
 
 --------------------------
 {Singularity} Docker Image
 --------------------------
 
-It is possible to use a Dockerized Singularity,
-here is a sample ``compose.yaml`` (Singularity version 3.7.4) for use with Docker Compose:
+It is possible to use a Dockerized Singularity, here is a sample
+``compose.yaml`` (Singularity version 3.7.4) for use with Docker
+Compose:
 
 .. code-block:: none
 
@@ -825,9 +831,11 @@ here is a sample ``compose.yaml`` (Singularity version 3.7.4) for use with Docke
           - .:/root
         entrypoint: ["/bin/sh"]
 
-Singularity in Docker can have various disadvantages,
-but basic container operations will work.
-Currently, the intended use case is continuous integration,
-meaning that you should be able to build a Singularity container using this Docker Compose file.
-For more information see `issue#5 <https://github.com/sylabs/singularity-admindocs/issues/5#issuecomment-852307931>`_
-and the image's source `repo <https://github.com/singularityhub/singularity-docker#use-cases>`_
+Singularity in Docker can have various disadvantages, but basic
+container operations will work.  Currently, the intended use case is
+continuous integration, meaning that you should be able to build a
+Singularity container using this Docker Compose file.  For more
+information see `issue#5
+<https://github.com/sylabs/singularity-admindocs/issues/5#issuecomment-852307931>`_
+and the image's source `repo
+<https://github.com/singularityhub/singularity-docker#use-cases>`_

--- a/installation.rst
+++ b/installation.rst
@@ -354,7 +354,7 @@ instructions on go installation page).
 
 .. code-block:: none
 
-    $ export VERSION=1.14.12 OS=linux ARCH=amd64 && \
+    $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
         wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
         sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
         rm go$VERSION.$OS-$ARCH.tar.gz

--- a/replacements.py
+++ b/replacements.py
@@ -23,6 +23,8 @@ variable_replacements = {
     # replace to SingularityPRO so that it is clearer where docs
     # diverge a bit from Singularity<->SingularityPRO due to long-term backports etc.
     "{Singularity}": "Singularity",
+    # Version of Go to be used in install instructions
+    "{GoVersion}": "1.17.1"
 }
 
 

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -26,14 +26,15 @@ without being root on the host outside.
    building or running a container.
 
 .. _userns-requirements:
-   
+
 ---------------------------
 User Namespace Requirements
 ---------------------------
 
 To allow unprivileged creation of user namespaces a kernel >=3.8 is
 required, with >=3.18 being recommended due to security fixes for user
-namespaces (3.18 also adds OverlayFS support which is used by Singularity).
+namespaces (3.18 also adds OverlayFS support which is used by
+Singularity).
 
 Additionally, some Linux distributions require that unprivileged user
 namespace creation is enabled using a ``sysctl`` or kernel command
@@ -62,9 +63,9 @@ From 7.4, kernel support is included but must be enabled with:
   sudo sysctl -p /etc/sysctl.d /etc/sysctl.d/90-max_net_namespaces.conf
 
 .. _userns-limitations:
-  
+
 --------------------------
-Unprivileged Installations  
+Unprivileged Installations
 --------------------------
 
 As detailed in the :ref:`non-setuid installation <install-nonsetuid>`
@@ -72,10 +73,10 @@ section, {Singularity} can be compiled or configured with the ``allow
 setuid = no`` option in ``singularity.conf`` to not perform privileged
 operations using the ``starter-setuid`` binary.
 
-When {Singularity} does not use ``setuid`` all container execution will
-use a user namespace. In this mode of operation, some features are not
-available, and there are impacts to the security/integrity guarantees
-when running SIF container images:
+When {Singularity} does not use ``setuid`` all container execution
+will use a user namespace. In this mode of operation, some features
+are not available, and there are impacts to the security/integrity
+guarantees when running SIF container images:
 
  - All containers must be run from sandbox directories. SIF images are
    extracted to a sandbox directory on the fly, preventing
@@ -127,8 +128,8 @@ In addition to user namespace support, {Singularity} must manipulate
 default this happens transparently in the setuid workflow. With
 unprivileged installations of {Singularity} or where ``allow setuid =
 no`` is set in ``singularity.conf``, {Singularity} attempts to use
-external setuid binaries ``newuidmap`` and ``newgidmap``, so you
-need to install those binaries on your system.
+external setuid binaries ``newuidmap`` and ``newgidmap``, so you need
+to install those binaries on your system.
 
 
 Basics
@@ -172,8 +173,8 @@ Same for ``/etc/subgid``:
 
 .. warning::
 
-  {Singularity} requires that a range of at least ``65536`` IDs is used
-  for each mapping. Larger ranges may be defined without error.
+  {Singularity} requires that a range of at least ``65536`` IDs is
+  used for each mapping. Larger ranges may be defined without error.
 
   It is also important to ensure that the subuid and subgid ranges
   defined in these files don't overlap with eachother, or any real
@@ -259,17 +260,17 @@ configured to use a network veth pair.
   the network.
 
 .. _config-fakeroot:
-  
+
 Configuration with ``config fakeroot``
 ======================================
 
-{Singularity} 3.5 and above provides a ``config fakeroot`` command that
-can be used by a root user to administer local system ``/etc/subuid``
-and ``/etc/subgid`` files in a simple manner. This allows users to be
-granted the ability to use Singularity's fakeroot functionality
-without editing the files manually. The ``config fakeroot`` command
-will automatically ensure that generated subuid/subgid ranges are an
-approriate size, and do not overlap.
+{Singularity} 3.5 and above provides a ``config fakeroot`` command
+that can be used by a root user to administer local system
+``/etc/subuid`` and ``/etc/subgid`` files in a simple manner. This
+allows users to be granted the ability to use Singularity's fakeroot
+functionality without editing the files manually. The ``config
+fakeroot`` command will automatically ensure that generated
+subuid/subgid ranges are an approriate size, and do not overlap.
 
 ``config fakeroot`` must be run as the ``root`` user, or via ``sudo
 singularity config fakeroot`` as the ``/etc/subuid`` and
@@ -293,15 +294,16 @@ existing mappings.
 Adding a fakeroot mapping
 --------------------------
 
-Use the ``-a/--add <user>`` option to ``config fakeroot`` to create new
-mapping entries so that ``<user>`` can use the fakeroot feature of Singularity:
- 
+Use the ``-a/--add <user>`` option to ``config fakeroot`` to create
+new mapping entries so that ``<user>`` can use the fakeroot feature of
+Singularity:
+
  .. code-block:: none
 
   $ sudo singularity config fakeroot --add dave
 
   # Show generated `/etc/subuid`
-  $ cat /etc/subuid 
+  $ cat /etc/subuid
   1000:4294836224:65536
 
   # Show generated `/etc/subgid`
@@ -315,7 +317,7 @@ mapping entries so that ``<user>`` can use the fakeroot feature of Singularity:
  with real UIDs on most systems.
 
 .. note::
-  
+
    The ``config fakeroot`` command generates mappings specified using
    the user's uid, rather than their username. This is the preferred
    format for faster lookups when configuring a large number of
@@ -323,7 +325,7 @@ mapping entries so that ``<user>`` can use the fakeroot feature of Singularity:
    username.
 
 
-Deleting, disabling, enabling mappings 
+Deleting, disabling, enabling mappings
 --------------------------------------
 
 Use the ``-r/--remove <user>`` option to ``config fakeroot`` to
@@ -341,7 +343,7 @@ able to use the fakeroot feature of Singularity:
    the prior user that were created with this mapping will be
    accessible to the new user via fakeroot.
 
-  
+
 The ``-d/--disable`` and ``-e/--enable`` options will comment and
 uncomment entries in the mapping files, to temporarily disable and
 subsequently re-enable fakeroot functionality for a user. This can be
@@ -360,8 +362,7 @@ user.
 
   # Enable dave
   $ sudo singularity config fakeroot --enable dave
-  
+
   # Entry is active
   $ cat /etc/subuid
   1000:4294836224:65536
-  


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-admindocs#28

The original PR description was:

> Bump version numbers to 3.9 so the new content is confused as being appropriate for 3.8
>
> Use same CSS as userdocs so the background color behind logo matches in HTML.
>
> Reformat the rst source files for consistent wrapping, no trailing spaces, etc. etc.