### PR TITLE
Reformat with rstfmt, from sylabs 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,43 +61,31 @@ Some hints on how to write stuff on RST are described in this section.
 
 #### **1. Create a section/subsection/subsubsection title**
 
-Sections are all described as plain text, but have specific
-notations/underlining for titles and subtitles, very similar to Markup Language.
+Section titles are defined by surrounding or underlining them with different
+characters. Each combination of overline/underline and character used represents
+a different level section. We follow the conventions used by the python
+documentation for headers:
 
-- To create a main section title: A main section title is described as a
-surrounded text (above and below) of ``=`` characters. Like in the following
-example:
+```rst
+##################
+H1: document title
+##################
 
-```sh
-================
-New Main Section
-================
-```
+*********
+Sample H2
+*********
 
-- To create a sub-section: A sub section title is described as a surrounded text
-(above and below) of ``-`` characters. Like in the following example:
+Sample H3
+=========
 
-```sh
----------------
-New Sub section
----------------
-```
+Sample H4
+---------
 
-- To create a sub-sub-section: A sub-sub section title is described as a text
-underlined by ``=`` characters. Like in the following example:
+Sample H5
+^^^^^^^^^
 
-```sh
-New sub-sub section
-===================
-```
-
-- Last but not least, could happen that you would need to insert a sub-sub-sub
-section, in that case the title is described as a text underlined by ``-``
-characters. Like in the following example:
-
-```sh
-New sub-sub-sub section
------------------------
+Sample H6
+"""""""""
 ```
 
 #### 2. Reference sections

--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -1,70 +1,73 @@
-=================
-Admin Quick Start
-=================
+###################
+ Admin Quick Start
+###################
 
-This quick start gives an overview of installation of {Singularity}
-from source, a description of the architecture of {Singularity}, and
-pointers to configuration files. More information, including alternate
+This quick start gives an overview of installation of {Singularity} from
+source, a description of the architecture of {Singularity}, and pointers
+to configuration files. More information, including alternate
 installation options and detailed configuration options can be found
 later in this guide.
 
 .. _singularity-architecture:
 
------------------------------
-Architecture of {Singularity}
------------------------------
+*******************************
+ Architecture of {Singularity}
+*******************************
 
-{Singularity} is designed to allow containers to be executed as if
-they were native programs or scripts on a host system. No daemon is
-required to build or run containers, and the security model is
-compatible with shared systems.
+{Singularity} is designed to allow containers to be executed as if they
+were native programs or scripts on a host system. No daemon is required
+to build or run containers, and the security model is compatible with
+shared systems.
 
-As a result, integration with clusters and schedulers such as Univa
-Grid Engine, Torque, SLURM, SGE, and many others is as simple as
-running any other command. All standard input, output, errors, pipes,
-IPC, and other communication pathways used by locally running programs
-are synchronized with the applications running locally within the
-container.
+As a result, integration with clusters and schedulers such as Univa Grid
+Engine, Torque, SLURM, SGE, and many others is as simple as running any
+other command. All standard input, output, errors, pipes, IPC, and other
+communication pathways used by locally running programs are synchronized
+with the applications running locally within the container.
 
 {Singularity} favors an 'integration over isolation' approach to
 containers. By default only the mount namespace is isolated for
 containers, so that they have their own filesystem view. Access to
 hardware such as GPUs, high speed networks, and shared filesystems is
-easy and does not require special configuration. User home
-directories, ``/tmp`` space, and installation specific mounts make it
-simple for users to benefit from the reproducibility of containerized
-applications without major changs to their existing workflows. Where
-more complete isolation is important, {Singularity} can use additional
-Linux namespaces and other security and resource limits to accomplish
-this.
+easy and does not require special configuration. User home directories,
+``/tmp`` space, and installation specific mounts make it simple for
+users to benefit from the reproducibility of containerized applications
+without major changs to their existing workflows. Where more complete
+isolation is important, {Singularity} can use additional Linux
+namespaces and other security and resource limits to accomplish this.
 
 .. _singularity-security:
 
-----------------------
-{Singularity} Security
-----------------------
+************************
+ {Singularity} Security
+************************
 
 {Singularity} uses a number of strategies to provide safety and
 ease-of-use on both single-user and shared systems. Notable security
 features include:
 
- - The user inside a container is the same as the user who ran the
-   container. This means access to files and devices from the
-   container is easily controlled with standard POSIX permissions.
- - Container filesystems are mounted ``nosuid`` and container
-   applications run with the ``PR_NO_NEW_PRIVS`` flag set. This means
-   that applications in a container cannot gain additional
-   privileges. A regular user cannot ``sudo`` or otherwise gain root
-   privilege on the host via a container.
- - The Singularity Image Format (SIF) supports encryption of containers,
-   as well as cryptographic signing and verification of their content.
- - SIF containers are immutable and their payload is run directly,
-   without extraction to disk. This means that the container can
-   always be verified, even at runtime, and encrypted content is not
-   exposed on disk.
- - Restrictions can be configured to limit the ownership, location,
-   and cryptographic signatures of containers that are permitted to be
-   run.
+   -  The user inside a container is the same as the user who ran the
+      container. This means access to files and devices from the
+      container is easily controlled with standard POSIX permissions.
+
+   -  Container filesystems are mounted ``nosuid`` and container
+      applications run with the ``PR_NO_NEW_PRIVS`` flag set. This means
+      that applications in a container cannot gain additional
+      privileges. A regular user cannot ``sudo`` or otherwise gain root
+      privilege on the host via a container.
+
+   -  The Singularity Image Format (SIF) supports encryption of
+      containers, as well as cryptographic signing and verification of
+      their content.
+
+   -  SIF containers are immutable and their payload is run directly,
+      without extraction to disk. This means that the container can
+      always be verified, even at runtime, and encrypted content is not
+      exposed on disk.
+
+   -  Restrictions can be configured to limit the ownership, location,
+      and cryptographic signatures of containers that are permitted to
+      be run.
 
 To support the SIF image format, automated networking setup etc., and
 older Linux distributions without user namespace support, Singularity
@@ -78,18 +81,17 @@ but :ref:`can be disabled <install-nonsetuid>` on build, or in the
 .. note::
 
    Running {Singularity} in non-setuid mode requires unprivileged user
-   namespace support in the operating system kernel and does not
-   support all features, most notably direct mounts of SIF
-   images. This impacts integrity/security guarantees of containers at
-   runtime.
+   namespace support in the operating system kernel and does not support
+   all features, most notably direct mounts of SIF images. This impacts
+   integrity/security guarantees of containers at runtime.
 
    See the :ref:`non-setuid installation section <install-nonsetuid>`
    for further detail on how to install {Singularity} to run in
    non-setuid mode.
 
-------------------------
-Installation from Source
-------------------------
+**************************
+ Installation from Source
+**************************
 
 {Singularity} can be installed from source directly, or by building an
 RPM package from the source. Linux distributions may also package
@@ -102,21 +104,20 @@ below. Other methods are discussed in the :ref:`Installation
 
 .. Note::
 
-    This quick-start that you will install as ``root`` using ``sudo``,
-    so that {Singularity} uses the default ``setuid`` workflow, and
-    all features are available. See the :ref:`non-setuid installation
-    <install-nonsetuid>` section of this guide for detail of how to
-    install as a non-root user, and how this affects the functionality
-    of {Singularity}.
-
+   This quick-start that you will install as ``root`` using ``sudo``, so
+   that {Singularity} uses the default ``setuid`` workflow, and all
+   features are available. See the :ref:`non-setuid installation
+   <install-nonsetuid>` section of this guide for detail of how to
+   install as a non-root user, and how this affects the functionality of
+   {Singularity}.
 
 Install Dependencies
---------------------
+====================
 
 On Red Hat Enterprise Linux or CentOS install the following
 dependencies:
 
-.. code-block:: sh
+.. code:: sh
 
    $ sudo yum update -y && \
         sudo yum groupinstall -y 'Development Tools' && \
@@ -128,28 +129,27 @@ dependencies:
         squashfs-tools \
         cryptsetup
 
-
 On Ubuntu or Debian install the following dependencies:
 
-.. code-block:: sh
+.. code:: sh
 
-    $ sudo apt-get update && sudo apt-get install -y \
-        build-essential \
-        uuid-dev \
-        libgpgme-dev \
-        squashfs-tools \
-        libseccomp-dev \
-        wget \
-        pkg-config \
-        git \
-        cryptsetup-bin
+   $ sudo apt-get update && sudo apt-get install -y \
+       build-essential \
+       uuid-dev \
+       libgpgme-dev \
+       squashfs-tools \
+       libseccomp-dev \
+       wget \
+       pkg-config \
+       git \
+       cryptsetup-bin
 
 Install Go
-----------
+==========
 
 {Singularity} v3 is written primarily in Go, and you will need Go 1.13
-or above installed to compile it from source. Versions of Go packaged
-by your distribution may not be new enough to build {Singularity}.
+or above installed to compile it from source. Versions of Go packaged by
+your distribution may not be new enough to build {Singularity}.
 
 The method below is one of several ways to `install and configure Go
 <https://golang.org/doc/install>`_.
@@ -158,97 +158,93 @@ The method below is one of several ways to `install and configure Go
 
    If you have previously installed Go from a download, rather than an
    operating system package, you should remove your ``go`` directory,
-   e.g. ``rm -r /usr/local/go`` before installing a newer
-   version. Extracting a new version of Go over an existing
-   installation can lead to errors when building Go programs, as it
-   may leave old files, which have been removed or replaced in newer
-   versions.
-
+   e.g. ``rm -r /usr/local/go`` before installing a newer version.
+   Extracting a new version of Go over an existing installation can lead
+   to errors when building Go programs, as it may leave old files, which
+   have been removed or replaced in newer versions.
 
 Visit the `Go download page <https://golang.org/dl/>`_ and pick a
 package archive to download. Copy the link address and download with
-wget.  Then extract the archive to ``/usr/local`` (or use other
+wget. Then extract the archive to ``/usr/local`` (or use other
 instructions on go installation page).
 
-.. code-block:: none
+.. code::
 
-    $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
-        wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
-        sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
-        rm go$VERSION.$OS-$ARCH.tar.gz
+   $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
+       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+       rm go$VERSION.$OS-$ARCH.tar.gz
 
 Then, set up your environment for Go.
 
-.. code-block:: none
+.. code::
 
-    $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
-        echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
-        source ~/.bashrc
-
+   $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
+       echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
+       source ~/.bashrc
 
 Download {Singularity} from a GitHub release
---------------------------------------------
+============================================
 
 You can download {Singularity} from one of the releases. To see a full
 list, visit `the GitHub release page
-<https://github.com/hpcng/singularity/releases>`_.  After deciding on
-a release to install, you can run the following commands to proceed
-with the installation.
+<https://github.com/hpcng/singularity/releases>`_.  After deciding on a
+release to install, you can run the following commands to proceed with
+the installation.
 
-.. code-block:: none
+.. code::
 
     $ export VERSION={InstallationVersion} && # adjust this as necessary \
         wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
         tar -xzf singularity-${VERSION}.tar.gz && \
         cd singularity
 
-
 Compile & Install {Singularity}
--------------------------------
+===============================
 
-{Singularity} uses a custom build system called ``makeit``.
-``mconfig`` is called to generate a ``Makefile`` and then ``make`` is
-used to compile and install.
+{Singularity} uses a custom build system called ``makeit``. ``mconfig``
+is called to generate a ``Makefile`` and then ``make`` is used to
+compile and install.
 
-.. code-block:: none
+.. code::
 
-    $ ./mconfig && \
-        make -C ./builddir && \
-        sudo make -C ./builddir install
+   $ ./mconfig && \
+       make -C ./builddir && \
+       sudo make -C ./builddir install
 
 By default {Singularity} will be installed in the ``/usr/local``
 directory hierarchy. You can specify a custom directory with the
 ``--prefix`` option, to ``mconfig``:
 
-.. code-block:: none
+.. code::
 
-    $ ./mconfig --prefix=/opt/singularity
+   $ ./mconfig --prefix=/opt/singularity
 
 This option can be useful if you want to install multiple versions of
 Singularity, install a personal version of {Singularity} on a shared
 system, or if you want to remove {Singularity} easily after installing
 it.
 
-For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
-are some of the most common options that you may need to use when
-building {Singularity} from source.
+For a full list of ``mconfig`` options, run ``mconfig --help``. Here are
+some of the most common options that you may need to use when building
+{Singularity} from source.
 
-- ``--sysconfdir``: Install read-only config files in sysconfdir.
-  This option is important if you need the ``singularity.conf`` file
-  or other configuration files in a custom location.
+-  ``--sysconfdir``: Install read-only config files in sysconfdir. This
+   option is important if you need the ``singularity.conf`` file or
+   other configuration files in a custom location.
 
-- ``--localstatedir``: Set the state directory where containers are
-  mounted. This is a particularly important option for administrators
-  installing {Singularity} on a shared file system.  The
-  ``--localstatedir`` should be set to a directory that is present on
-  each individual node.
+-  ``--localstatedir``: Set the state directory where containers are
+   mounted. This is a particularly important option for administrators
+   installing {Singularity} on a shared file system. The
+   ``--localstatedir`` should be set to a directory that is present on
+   each individual node.
 
-- ``-b``: Build {Singularity} in a given directory. By default this is
-  ``./builddir``.
+-  ``-b``: Build {Singularity} in a given directory. By default this is
+   ``./builddir``.
 
--------------
-Configuration
--------------
+***************
+ Configuration
+***************
 
 {Singularity} is configured using files under ``etc/singularity`` in
 your ``--prefix``, or ``--syconfdir`` if you used that option with
@@ -265,19 +261,18 @@ network, and resource configuration. Head over to the
 :ref:`Configuration files <singularity_configfiles>` section where the
 files and configuration options are discussed.
 
-------------------
-Test {Singularity}
-------------------
+********************
+ Test {Singularity}
+********************
 
 You can run a quick test of {Singularity} using a container in the
 Sylabs Container Library:
 
-.. code-block:: none
+.. code::
 
-    $ singularity exec library://alpine cat /etc/alpine-release
-    3.9.2
-
+   $ singularity exec library://alpine cat /etc/alpine-release
+   3.9.2
 
 See the `user guide
-<\{userdocs\}>`__ for more
+<{userdocs}>`__ for more
 information about how to use {Singularity}.

--- a/appendix.rst
+++ b/appendix.rst
@@ -1,67 +1,66 @@
-
 .. _installed-files:
 
-===============
-Installed Files
-===============
+#################
+ Installed Files
+#################
 
 An installation of {Singularity} {InstallationVersion}, performed as
 root via ``sudo make install`` consists of the following files, with
 ownership and permissions required to use the `setuid` workflow:
 
-.. code-block:: none
+.. code::
 
-    # Container session / state
-    var/singularity root:root 755 (drwxr-xr-x)
-    var/singularity/mnt root:root 755 (drwxr-xr-x)
-    var/singularity/mnt/session root:root 755 (drwxr-xr-x)
+   # Container session / state
+   var/singularity root:root 755 (drwxr-xr-x)
+   var/singularity/mnt root:root 755 (drwxr-xr-x)
+   var/singularity/mnt/session root:root 755 (drwxr-xr-x)
 
-    # Main executables
-    bin/singularity root:root 755 (-rwxr-xr-x)
-    bin/run-singularity root:root 755 (-rwxr-xr-x)
+   # Main executables
+   bin/singularity root:root 755 (-rwxr-xr-x)
+   bin/run-singularity root:root 755 (-rwxr-xr-x)
 
-    # Helper executables
-    libexec/singularity root:root 755 (drwxr-xr-x)
-    libexec/singularity/bin root:root 755 (drwxr-xr-x)
-    libexec/singularity/bin/starter root:root 755 (-rwxr-xr-x)
-    libexec/singularity/bin/starter-suid root:root 4755 (-rwsr-xr-x)
-    libexec/singularity/cni root:root 755 (drwxr-xr-x)
-    libexec/singularity/cni/bandwidth root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/bridge root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/dhcp root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/firewall root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/flannel root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/host-device root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/host-local root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/ipvlan root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/loopback root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/macvlan root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/portmap root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/ptp root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/static root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/tuning root:root 755 (-rwxr-xr-x)
-    libexec/singularity/cni/vlan root:root 755 (-rwxr-xr-x)
+   # Helper executables
+   libexec/singularity root:root 755 (drwxr-xr-x)
+   libexec/singularity/bin root:root 755 (drwxr-xr-x)
+   libexec/singularity/bin/starter root:root 755 (-rwxr-xr-x)
+   libexec/singularity/bin/starter-suid root:root 4755 (-rwsr-xr-x)
+   libexec/singularity/cni root:root 755 (drwxr-xr-x)
+   libexec/singularity/cni/bandwidth root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/bridge root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/dhcp root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/firewall root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/flannel root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/host-device root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/host-local root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/ipvlan root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/loopback root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/macvlan root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/portmap root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/ptp root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/static root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/tuning root:root 755 (-rwxr-xr-x)
+   libexec/singularity/cni/vlan root:root 755 (-rwxr-xr-x)
 
-    # Singularity configuration
-    etc/singularity root:root 755 (drwxr-xr-x)
-    etc/singularity/capability.json root:root 644 (-rw-r--r--)
-    etc/singularity/cgroups root:root 755 (drwxr-xr-x)
-    etc/singularity/cgroups/cgroups.toml root:root 644 (-rw-r--r--)
-    etc/singularity/ecl.toml root:root 644 (-rw-r--r--)
-    etc/singularity/global-pgp-public root:root 644 (-rw-r--r--)
-    etc/singularity/network root:root 755 (drwxr-xr-x)
-    etc/singularity/network/00_bridge.conflist root:root 644 (-rw-r--r--)
-    etc/singularity/network/10_ptp.conflist root:root 644 (-rw-r--r--)
-    etc/singularity/network/20_ipvlan.conflist root:root 644 (-rw-r--r--)
-    etc/singularity/network/30_macvlan.conflist root:root 644 (-rw-r--r--)
-    etc/singularity/network/40_fakeroot.conflist root:root 644 (-rw-r--r--)
-    etc/singularity/nvliblist.conf root:root 644 (-rw-r--r--)
-    etc/singularity/remote.yaml root:root 644 (-rw-r--r--)
-    etc/singularity/rocmliblist.conf root:root 644 (-rw-r--r--)
-    etc/singularity/seccomp-profiles root:root 755 (drwxr-xr-x)
-    etc/singularity/seccomp-profiles/default.json root:root 644 (-rw-r--r--)
-    etc/singularity/singularity.conf root:root 644 (-rw-r--r--)
+   # Singularity configuration
+   etc/singularity root:root 755 (drwxr-xr-x)
+   etc/singularity/capability.json root:root 644 (-rw-r--r--)
+   etc/singularity/cgroups root:root 755 (drwxr-xr-x)
+   etc/singularity/cgroups/cgroups.toml root:root 644 (-rw-r--r--)
+   etc/singularity/ecl.toml root:root 644 (-rw-r--r--)
+   etc/singularity/global-pgp-public root:root 644 (-rw-r--r--)
+   etc/singularity/network root:root 755 (drwxr-xr-x)
+   etc/singularity/network/00_bridge.conflist root:root 644 (-rw-r--r--)
+   etc/singularity/network/10_ptp.conflist root:root 644 (-rw-r--r--)
+   etc/singularity/network/20_ipvlan.conflist root:root 644 (-rw-r--r--)
+   etc/singularity/network/30_macvlan.conflist root:root 644 (-rw-r--r--)
+   etc/singularity/network/40_fakeroot.conflist root:root 644 (-rw-r--r--)
+   etc/singularity/nvliblist.conf root:root 644 (-rw-r--r--)
+   etc/singularity/remote.yaml root:root 644 (-rw-r--r--)
+   etc/singularity/rocmliblist.conf root:root 644 (-rw-r--r--)
+   etc/singularity/seccomp-profiles root:root 755 (drwxr-xr-x)
+   etc/singularity/seccomp-profiles/default.json root:root 644 (-rw-r--r--)
+   etc/singularity/singularity.conf root:root 644 (-rw-r--r--)
 
-    # Bash completion configuration
-    etc/bash_completion.d root:root 755 (drwxr-xr-x)
-    etc/bash_completion.d/singularity root:root 644 (-rw-r--r--)
+   # Bash completion configuration
+   etc/bash_completion.d root:root 755 (drwxr-xr-x)
+   etc/bash_completion.d/singularity root:root 644 (-rw-r--r--)

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -1,82 +1,79 @@
 .. _singularity_configfiles:
 
-=================================
-{Singularity} Configuration Files
-=================================
+###################################
+ {Singularity} Configuration Files
+###################################
 
 As a {Singularity} Administrator, you will have access to various
 configuration files, that will let you manage container resources, set
-security restrictions and configure network options etc, when
-installing {Singularity} across the system.  All these files can be
-found in ``/usr/local/etc/singularity`` by default (though its
-location will obviously differ based on options passed during the
-installation). This page will describe the following configuration
-files and the various parameters contained by them. They are usually
-self documenting but here are several things to pay special attention
-to:
+security restrictions and configure network options etc, when installing
+{Singularity} across the system. All these files can be found in
+``/usr/local/etc/singularity`` by default (though its location will
+obviously differ based on options passed during the installation). This
+page will describe the following configuration files and the various
+parameters contained by them. They are usually self documenting but here
+are several things to pay special attention to:
 
-----------------
-singularity.conf
-----------------
+******************
+ singularity.conf
+******************
 
 Most of the configuration options are set using the file
 ``singularity.conf`` that defines the global configuration for
-{Singularity} across the entire system.  Using this file, system
+{Singularity} across the entire system. Using this file, system
 administrators can have direct say as to what functions the users can
 utilize. As a security measure, for ``setuid`` installations of
-{Singularity} it must be owned by root and must not be writable by
-users or {Singularity} will refuse to run. This is not the case for
+{Singularity} it must be owned by root and must not be writable by users
+or {Singularity} will refuse to run. This is not the case for
 ``non-setuid`` installations that will only ever execute with user
 priviledge and thus do not require such limitations. The options for
-this configuration are listed below.  Options are grouped together
-based on relevance, the order of options within ``singularity.conf``
-differs.
+this configuration are listed below. Options are grouped together based
+on relevance, the order of options within ``singularity.conf`` differs.
 
 Setuid and Capabilities
 =======================
 
 ``allow setuid``: To use all features of {Singularity} containers,
-{Singularity} will need to have access to some privileged system
-calls. One way {Singularity} achieves this is by using binaries with
-the ``setuid`` bit enabled. This variable lets you enable/disable
-users ability to utilize these binaries within {Singularity}. By
-default, it is set to "yes", but when disabled, various {Singularity}
-features will not function. Please see :ref:`Unprivileged
-Installations <userns-limitations>` for more information about running
-{Singularity} without ``setuid`` enabled.
+{Singularity} will need to have access to some privileged system calls.
+One way {Singularity} achieves this is by using binaries with the
+``setuid`` bit enabled. This variable lets you enable/disable users
+ability to utilize these binaries within {Singularity}. By default, it
+is set to "yes", but when disabled, various {Singularity} features will
+not function. Please see :ref:`Unprivileged Installations
+<userns-limitations>` for more information about running {Singularity}
+without ``setuid`` enabled.
 
-``root default capabilities``: {Singularity} allows the specification
-of capabilities kept by the root user when running a container by
-default. Options include:
+``root default capabilities``: {Singularity} allows the specification of
+capabilities kept by the root user when running a container by default.
+Options include:
 
-* full: all capabilities are maintained, this gives the same behavior
-  as the ``--keep-privs`` option.
-* file: only capabilities granted in
-  ``/usr/local/etc/singularity/capabilities/user.root`` are
-  maintained.
-* no: no capabilities are maintained, this gives the same behavior as
-  the ``--no-privs`` option.
+-  full: all capabilities are maintained, this gives the same behavior
+   as the ``--keep-privs`` option.
+-  file: only capabilities granted in
+   ``/usr/local/etc/singularity/capabilities/user.root`` are maintained.
+-  no: no capabilities are maintained, this gives the same behavior as
+   the ``--no-privs`` option.
 
 .. note::
 
-  The root user can manage the capabilities granted to individual
-  containers when they are launched through the ``--add-caps`` and
-  ``drop-caps`` flags.  Please see `Linux Capabilities
-  <\{userdocs\}/security_options.html#linux-capabilities>`_
-  in the user guide for more information.
+   The root user can manage the capabilities granted to individual
+   containers when they are launched through the ``--add-caps`` and
+   ``drop-caps`` flags. Please see `Linux Capabilities
+   <{userdocs}/security_options.html#linux-capabilities>`_
+   in the user guide for more information.
 
 Loop Devices
 ============
 
-{Singularity} uses loop devices to facilitate the mounting of
-container filesystems from SIF images.
+{Singularity} uses loop devices to facilitate the mounting of container
+filesystems from SIF images.
 
 ``max loop devices``: This option allows an admin to limit the total
 number of loop devices {Singularity} will consume at a given time.
 
 ``shared loop devices``: This allows containers running the same image
-to share a single loop device.  This minimizes loop device usage and
-helps optimize kernel cache usage.  Enabling this feature can be
+to share a single loop device. This minimizes loop device usage and
+helps optimize kernel cache usage. Enabling this feature can be
 particularly useful for MPI jobs.
 
 Namespace Options
@@ -85,9 +82,10 @@ Namespace Options
 ``allow pid ns``: This option determines if users can leverage the PID
 namespace when running their containers through the ``--pid`` flag.
 
-.. note:: For some HPC systems, using the PID namespace has the
-  potential of confusing some resource managers as well as some MPI
-  implementations.
+.. note::
+
+   For some HPC systems, using the PID namespace has the potential of
+   confusing some resource managers as well as some MPI implementations.
 
 Configuration Files
 ===================
@@ -97,154 +95,149 @@ configuration files within containers to ease usage across systems.
 
 .. note::
 
-  These options will do nothing unless the file or directory path
-  exists within the container or {Singularity} has either overlay or
-  underlay support enabled.
+   These options will do nothing unless the file or directory path
+   exists within the container or {Singularity} has either overlay or
+   underlay support enabled.
 
 ``config passwd``: This option determines if {Singularity} should
 automatically append an entry to ``/etc/passwd`` for the user running
 the container.
 
 ``config group``: This option determines if {Singularity} should
-automatically append the calling user's group entries to the
-containers ``/etc/group``.
+automatically append the calling user's group entries to the containers
+``/etc/group``.
 
 ``config resolv_conf``: This option determines if {Singularity} should
-automatically bind the host's ``/etc/resolv/conf`` within the
-container.
+automatically bind the host's ``/etc/resolv/conf`` within the container.
 
 Session Directory and System Mounts
 ===================================
 
 ``sessiondir max size``: In order for the {Singularity} runtime to
-create a container it needs to create a ``sessiondir`` to manage
-various components of the container, including mounting filesystems
-over the base image filesystem. This option specifies how large the
-default ``sessiondir`` should be (in MB) and will only affect users
-who use the ``--contain`` options without also specifying a location
-to perform default read/writes to via the ``--workdir`` or ``--home``
-options.
+create a container it needs to create a ``sessiondir`` to manage various
+components of the container, including mounting filesystems over the
+base image filesystem. This option specifies how large the default
+``sessiondir`` should be (in MB) and will only affect users who use the
+``--contain`` options without also specifying a location to perform
+default read/writes to via the ``--workdir`` or ``--home`` options.
 
 ``mount proc``: This option determines if {Singularity} should
 automatically bind mount ``/proc`` within the container.
 
-``mount sys``:
-This option determines if {Singularity} should automatically bind mount ``/sys``
-within the container.
+``mount sys``: This option determines if {Singularity} should
+automatically bind mount ``/sys`` within the container.
 
 ``mount dev``: Should be set to "YES", if you want {Singularity} to
 automatically bind mount `/dev` within the container. If set to
-'minimal', then only 'null', 'zero', 'random', 'urandom', and 'shm'
-will be included.
+'minimal', then only 'null', 'zero', 'random', 'urandom', and 'shm' will
+be included.
 
 ``mount devpts``: This option determines if {Singularity} will mount a
 new instance of ``devpts`` when there is a ``minimal`` ``/dev``
 directory as explained above, or when the ``--contain`` option is
 passed.
 
-.. note:: This requires either a kernel configured with
-  ``CONFIG_DEVPTS_MULTIPLE_INSTANCES=y``, or a kernel version at or
-  newer than ``4.7``.
+.. note::
+
+   This requires either a kernel configured with
+   ``CONFIG_DEVPTS_MULTIPLE_INSTANCES=y``, or a kernel version at or
+   newer than ``4.7``.
 
 ``mount home``: When this option is enabled, {Singularity} will
-automatically determine the calling user's home directory and attempt
-to mount it into the container.
+automatically determine the calling user's home directory and attempt to
+mount it into the container.
 
 ``mount tmp``: When this option is enabled, {Singularity} will
 automatically bind mount ``/tmp`` and ``/var/tmp`` into the container
-from the host. If the ``--contain`` option is passed, {Singularity}
-will create both locations within the ``sessiondir`` or within the
-directory specified by the ``--workdir`` option if that is passed as
-well.
+from the host. If the ``--contain`` option is passed, {Singularity} will
+create both locations within the ``sessiondir`` or within the directory
+specified by the ``--workdir`` option if that is passed as well.
 
-``mount hostfs``: This option will cause {Singularity} to probe the
-host for all mounted filesystems and bind those into containers at
-runtime.
+``mount hostfs``: This option will cause {Singularity} to probe the host
+for all mounted filesystems and bind those into containers at runtime.
 
 ``mount slave``: {Singularity} automatically mounts a handful host
 system directories to the container by default. This option determines
-if filesystem changes on the host should automatically be propogated
-to those directories in the container.
+if filesystem changes on the host should automatically be propogated to
+those directories in the container.
 
 .. note::
 
-  This should be set to ``yes`` when autofs mounts in the system
-  should show up in the container.
+   This should be set to ``yes`` when autofs mounts in the system should
+   show up in the container.
 
 ``memory fs type``: This option allows admins to choose the temporary
 filesystem used by {Singularity}. Temporary filesystems are primarily
-used for system directories like ``/dev`` when the host system
-directory is not mounted within the container.
+used for system directories like ``/dev`` when the host system directory
+is not mounted within the container.
 
 .. note::
 
-  For Cray CLE 5 and 6, up to CLE 6.0.UP05, there is an issue (kernel
-  panic) when Singularity uses tmpfs, so on affected systems it's
-  recommended to set this value to ramfs to avoid a kernel panic
+   For Cray CLE 5 and 6, up to CLE 6.0.UP05, there is an issue (kernel
+   panic) when Singularity uses tmpfs, so on affected systems it's
+   recommended to set this value to ramfs to avoid a kernel panic
 
 Bind Mount Management
 =====================
 
 ``bind path``: This option is used for defining a list of files or
-directories to automatically be made available when {Singularity} runs
-a container.  In order to successfully mount listed paths the file or
+directories to automatically be made available when {Singularity} runs a
+container. In order to successfully mount listed paths the file or
 directory path must exist within the container, or {Singularity} has
 either overlay or underlay support enabled.
 
 .. note::
 
-  This option is ignored when containers are invoked with the
-  ``--contain`` option.
+   This option is ignored when containers are invoked with the
+   ``--contain`` option.
 
 You can define the a bind point where the source and destination are
 identical:
 
-.. code-block:: none
+.. code::
 
-  bind path = /etc/localtime
+   bind path = /etc/localtime
 
 Or you can specify different source and destination locations using:
 
-.. code-block:: none
+.. code::
 
-  bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
+   bind path = /etc/singularity/default-nsswitch.conf:/etc/nsswitch.conf
 
-
-``user bind control``: This allows admins to decide if users can
-define bind points at runtime.  By Default, this option is set to
-``YES``, which means users can specify bind points, scratch and tmp
-locations.
+``user bind control``: This allows admins to decide if users can define
+bind points at runtime. By Default, this option is set to ``YES``, which
+means users can specify bind points, scratch and tmp locations.
 
 Limiting Container Execution
 ============================
 
 There are several ways to limit container execution as an admin listed
-below.  If stricter controls are required, check out the
-:ref:`Execution Control List <execution_control_list>`.
+below. If stricter controls are required, check out the :ref:`Execution
+Control List <execution_control_list>`.
 
 ``limit container owners``: This restricts container execution to only
 allow conatiners that are owned by the specified user.
 
 .. note::
 
-  This feature will only apply when {Singularity} is running in SUID
-  mode and the user is non-root. By default this is set to `NULL`.
+   This feature will only apply when {Singularity} is running in SUID
+   mode and the user is non-root. By default this is set to `NULL`.
 
 ``limit container groups``: This restricts container execution to only
 allow conatiners that are owned by the specified group.
 
 .. note::
 
-  This feature will only apply when {Singularity} is running in SUID
-  mode and the user is non-root. By default this is set to `NULL`.
+   This feature will only apply when {Singularity} is running in SUID
+   mode and the user is non-root. By default this is set to `NULL`.
 
 ``limit container paths``: This restricts container execution to only
 allow containers that are located within the specified path prefix.
 
 .. note::
 
-  This feature will only apply when {Singularity} is running in SUID
-  mode and the user is non-root. By default this is set to `NULL`.
+   This feature will only apply when {Singularity} is running in SUID
+   mode and the user is non-root. By default this is set to `NULL`.
 
 ``allow container ${type}``: This option allows admins to limit the
 types of image formats that can be leveraged by users with
@@ -256,7 +249,7 @@ filesystem contents.
 
 .. note::
 
-  These limitations do not apply to the root user.
+   These limitations do not apply to the root user.
 
 Networking Options
 ==================
@@ -264,9 +257,9 @@ Networking Options
 The ``--network`` option can be used to specify a CNI networking
 configuration that will be used when running a container with `network
 virtualization
-<\{userdocs\}/networking.html>`_. Unrestricted
-use of CNI network configurations requires root privilege, as certain
-configurations may disrupt the host networking environment.
+<{userdocs}/networking.html>`_.
+Unrestricted use of CNI network configurations requires root privilege,
+as certain configurations may disrupt the host networking environment.
 
 {Singularity} 3.8 allows specific users or groups to be granted the
 ability to run containers with adminstrator specified CNI
@@ -286,29 +279,27 @@ execution where only 40_fakeroot.conflist is used. This feature only
 applies when {Singularity} is running in SUID mode and the user is
 non-root.
 
-``allow net networks``: Specify the names of CNI network
-configurations that may be used by users and groups listed in the
-allow net users / allow net groups directives. Thus feature only
-applies when {Singularity} is running in SUID mode and the user is
-non-root.
-
+``allow net networks``: Specify the names of CNI network configurations
+that may be used by users and groups listed in the allow net users /
+allow net groups directives. Thus feature only applies when
+{Singularity} is running in SUID mode and the user is non-root.
 
 GPU Options
 ===========
 
-{Singularity} provides integration with GPUs in order to facilitate
-GPU based workloads seamlessly. Both options listed below are
-particularly useful in GPU only environments. For more information on
-using GPUs with Singularity checkout :ref:`GPU Library Configuration
+{Singularity} provides integration with GPUs in order to facilitate GPU
+based workloads seamlessly. Both options listed below are particularly
+useful in GPU only environments. For more information on using GPUs with
+Singularity checkout :ref:`GPU Library Configuration
 <gpu_library_configuration>`.
 
-``always use nv``: Enabling this option will cause every action
-command (``exec/shell/run/instance``) to be executed with the ``--nv``
-option implicitly added.
+``always use nv``: Enabling this option will cause every action command
+(``exec/shell/run/instance``) to be executed with the ``--nv`` option
+implicitly added.
 
 ``always use rocm``: Enabling this option will cause every action
-command (``exec/shell/run/instance``) to be executed with the
-``--rocm`` option implicitly added.
+command (``exec/shell/run/instance``) to be executed with the ``--rocm``
+option implicitly added.
 
 Supplemental Filesystems
 ========================
@@ -316,17 +307,17 @@ Supplemental Filesystems
 ``enable fusemount``: This will allow users to mount fuse filesystems
 inside containers using the ``--fusemount`` flag.
 
-``enable overlay``: This option will allow {Singularity} to create
-bind mounts at paths that do not exist within the container
-image. This option can be set to ``try``, which will try to use an
-overlayfs. If it fails to create an overlayfs in this case the bind
-path will be silently ignored.
+``enable overlay``: This option will allow {Singularity} to create bind
+mounts at paths that do not exist within the container image. This
+option can be set to ``try``, which will try to use an overlayfs. If it
+fails to create an overlayfs in this case the bind path will be silently
+ignored.
 
-``enable underlay``: This option will allow {Singularity} to create
-bind mounts at paths that do not exist within the container image,
-just like ``enable overlay``, but instead using an underlay. This is
-suitable for systems where overlay is not possible or not working. If
-the overlay option is available and working, it will be used instead.
+``enable underlay``: This option will allow {Singularity} to create bind
+mounts at paths that do not exist within the container image, just like
+``enable overlay``, but instead using an underlay. This is suitable for
+systems where overlay is not possible or not working. If the overlay
+option is available and working, it will be used instead.
 
 CNI Configuration and Plugins
 =============================
@@ -334,12 +325,12 @@ CNI Configuration and Plugins
 ``cni configuration path``: This option allows admins to specify a
 custom path for the CNI configuration that {Singularity} will use for
 `Network Virtualization
-<\{userdocs\}/networking.html>`_.
+<{userdocs}/networking.html>`_.
 
-``cni plugin path``: This option allows admins to specify a custom
-path for {Singularity} to access CNI plugin executables. Check out the
+``cni plugin path``: This option allows admins to specify a custom path
+for {Singularity} to access CNI plugin executables. Check out the
 `Network Virtualization
-<\{userdocs\}/networking.html>`_
+<{userdocs}/networking.html>`_
 section of the user guide for more information.
 
 External Binaries
@@ -347,11 +338,11 @@ External Binaries
 
 {Singularity} calls a number of external binaries for full
 functionality. The paths for certain critical binaries can be set in
-``singularity.conf``. At build time, ``mconfig`` will set initial
-values for these, by searching on the ``$PATH`` environment
-variable. You can override which external binaries are called by
-changing the value in ``singularity.conf``. If left unset, ``$PATH``
-will be searched at runtime.
+``singularity.conf``. At build time, ``mconfig`` will set initial values
+for these, by searching on the ``$PATH`` environment variable. You can
+override which external binaries are called by changing the value in
+``singularity.conf``. If left unset, ``$PATH`` will be searched at
+runtime.
 
 ``cryptsetup path``: Path to the cryptsetup executable, used to work
 with encrypted containers. NOTE - cryptsetup is called as root, and is
@@ -365,107 +356,106 @@ libraries.
 ``mksquashfs path``: Path to the mksquashfs executable, used to create
 SIF and SquashFS containers.
 
-``mksquashfs procs``: Allows the administrator to specify the number
-of CPUs that mksquashfs may use when building an image.  The fewer
-processors the longer it takes.  To use all available CPU's set this
-to 0.
+``mksquashfs procs``: Allows the administrator to specify the number of
+CPUs that mksquashfs may use when building an image. The fewer
+processors the longer it takes. To use all available CPU's set this to
+0.
 
 ``mksquashfs mem``: Allows the administrator to set the maximum amount
-of memory that mksquashfs nay use when building an image.  e.g. 1G for
-1gb or 500M for 500mb. Restricting memory can have a major impact on
-the time it takes mksquashfs to create the image.  NOTE: This
-fuctionality did not exist in squashfs-tools prior to version 4.3.  If
-using an earlier version you should not set this.
+of memory that mksquashfs nay use when building an image. e.g. 1G for
+1gb or 500M for 500mb. Restricting memory can have a major impact on the
+time it takes mksquashfs to create the image. NOTE: This fuctionality
+did not exist in squashfs-tools prior to version 4.3. If using an
+earlier version you should not set this.
 
 ``nvidia-container-cli path``: Path to the nvidia-container-cli
-executable, used to find GPU libraries and configure the container
-when running with the ``--nvccli`` option. Required to be owned by
-root, and is called as root in setuid installations.
+executable, used to find GPU libraries and configure the container when
+running with the ``--nvccli`` option. Required to be owned by root, and
+is called as root in setuid installations.
 
-``unsquashfs path``: Path to the unsquashfs executable, used to
-extract SIF and SquashFS containers.
+``unsquashfs path``: Path to the unsquashfs executable, used to extract
+SIF and SquashFS containers.
 
 Updating Configuration Options
 ==============================
 
-In order to manage this configuration file, {Singularity} has a
-``config global`` command group that allows you to get, set, reset,
-and unset values through the
-CLI. It's important to note that these commands must be run with
-elevated priveledges because the ``singularity.conf`` can only be
-modified by an administrator.
+In order to manage this configuration file, {Singularity} has a ``config
+global`` command group that allows you to get, set, reset, and unset
+values through the CLI. It's important to note that these commands must
+be run with elevated priveledges because the ``singularity.conf`` can
+only be modified by an administrator.
 
 Example
 -------
 
 In this example we will changing the ``bind path`` option described
-above.  First we can see the current list of bind paths set within our
+above. First we can see the current list of bind paths set within our
 system configuration:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config global --get "bind path"
-  /etc/localtime,/etc/hosts
+   $ sudo singularity config global --get "bind path"
+   /etc/localtime,/etc/hosts
 
 Now we can add a new path and verify it was successfully added:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config global --set "bind path" /etc/resolv.conf
-  $ sudo singularity config global --get "bind path"
-  /etc/resolv.conf,/etc/localtime,/etc/hosts
+   $ sudo singularity config global --set "bind path" /etc/resolv.conf
+   $ sudo singularity config global --get "bind path"
+   /etc/resolv.conf,/etc/localtime,/etc/hosts
 
 From here we can remove a path with:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config global --unset "bind path" /etc/localtime
-  $ sudo singularity config global --get "bind path"
-  /etc/resolv.conf,/etc/hosts
+   $ sudo singularity config global --unset "bind path" /etc/localtime
+   $ sudo singularity config global --get "bind path"
+   /etc/resolv.conf,/etc/hosts
 
 If we want to reset the option to the default at installation, then we
 can reset it with:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config global --reset "bind path"
-  $ sudo singularity config global --get "bind path"
-  /etc/localtime,/etc/hosts
+   $ sudo singularity config global --reset "bind path"
+   $ sudo singularity config global --get "bind path"
+   /etc/localtime,/etc/hosts
 
 And now we are back to our original option settings. You can also test
 what a change would look like by using the ``--dry-run`` option in
 conjunction with the above commands. Instead of writing to the
 configuration file, it will output what would have been written to the
-configuration file if the command had been run without the
-``--dry-run`` option:
+configuration file if the command had been run without the ``--dry-run``
+option:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config global --dry-run --set "bind path" /etc/resolv.conf
-  # SINGULARITY.CONF
-  # This is the global configuration file for Singularity. This file controls
-  [...]
-  # BIND PATH: [STRING]
-  # DEFAULT: Undefined
-  # Define a list of files/directories that should be made available from within
-  # the container. The file or directory must exist within the container on
-  # which to attach to. you can specify a different source and destination
-  # path (respectively) with a colon; otherwise source and dest are the same.
-  # NOTE: these are ignored if singularity is invoked with --contain.
-  bind path = /etc/resolv.conf
-  bind path = /etc/localtime
-  bind path = /etc/hosts
-  [...]
-  $ sudo singularity config global --get "bind path"
-  /etc/localtime,/etc/hosts
+   $ sudo singularity config global --dry-run --set "bind path" /etc/resolv.conf
+   # SINGULARITY.CONF
+   # This is the global configuration file for Singularity. This file controls
+   [...]
+   # BIND PATH: [STRING]
+   # DEFAULT: Undefined
+   # Define a list of files/directories that should be made available from within
+   # the container. The file or directory must exist within the container on
+   # which to attach to. you can specify a different source and destination
+   # path (respectively) with a colon; otherwise source and dest are the same.
+   # NOTE: these are ignored if singularity is invoked with --contain.
+   bind path = /etc/resolv.conf
+   bind path = /etc/localtime
+   bind path = /etc/hosts
+   [...]
+   $ sudo singularity config global --get "bind path"
+   /etc/localtime,/etc/hosts
 
 Above we can see that ``/etc/resolv.conf`` is listed as a bind path in
 the output of the ``--dry-run`` command, but did not affect the actual
 bind paths of the system.
 
-------------
-cgroups.toml
-------------
+**************
+ cgroups.toml
+**************
 
 The cgroups (control groups) functionality of the Linux kernel allows
 you to limit and meter the resources used by a process, or group of
@@ -475,12 +465,14 @@ nodes.
 
 There are two versions of cgroups in common use. Cgroups v1 sets
 resource limits for a process within separate hierarchies per resource
-class. Cgroups v2, the default in newer Linux distributions,
-implements a unified hierarchy, simplifying the structure of resource
-limits on processes.
+class. Cgroups v2, the default in newer Linux distributions, implements
+a unified hierarchy, simplifying the structure of resource limits on
+processes.
 
-* v1 documentation: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
-* v2 documentation: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
+-  v1 documentation:
+   https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
+-  v2 documentation:
+   https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 
 {Singularity} 3.9 and above can apply resource limitations to systems
 configured for both cgroups v1 and the v2 unified hierarchy. Resource
@@ -488,9 +480,9 @@ limits are specified using a TOML file that represents the `resources`
 section of the OCI runtime-spec:
 https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#control-groups
 
-On a cgroups v1 system the resources configuration is applied
-directly. On a cgroups v2 system the configuration is translated and
-applied to the unified hierarchy.
+On a cgroups v1 system the resources configuration is applied directly.
+On a cgroups v2 system the configuration is translated and applied to
+the unified hierarchy.
 
 Under cgroups v1, access restrictions for device nodes are managed
 directly. Under cgroups v2, the restrictions are applied by attaching
@@ -498,11 +490,10 @@ eBPF programs that implement the requested access controls.
 
 .. note::
 
-   {Singularity} does not currently support applying native cgroups
-   v2 ``unified`` resource limit specifications. Use the cgroups v1
-   limits, which will be translated to v2 format when applied on a
-   cgroups v2 system.
-
+   {Singularity} does not currently support applying native cgroups v2
+   ``unified`` resource limit specifications. Use the cgroups v1 limits,
+   which will be translated to v2 format when applied on a cgroups v2
+   system.
 
 Examples
 ========
@@ -511,47 +502,46 @@ To apply resource limits to a container, use the ``--apply-cgroups``
 flag, which takes a path to a TOML file specifying the cgroups
 configuration to be applied:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
+   $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
 
 .. note::
 
-  The ``--apply-cgroups`` option can only be used with root privileges.
+   The ``--apply-cgroups`` option can only be used with root privileges.
 
 Limiting memory
 ---------------
 
 To limit the amount of memory that your container uses to 500MB
-(524288000 bytes), set a ``limit`` value inside the ``[memory]``
-section of your cgroups TOML file:
+(524288000 bytes), set a ``limit`` value inside the ``[memory]`` section
+of your cgroups TOML file:
 
-.. code-block:: none
+.. code::
 
-  [memory]
-      limit = 524288000
+   [memory]
+       limit = 524288000
 
 Start your container, applying the toml file, e.g.:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
+   $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
 
 After that, you can verify that the container is only using 500MB of
-memory.  This example assumes that there is only one running
-container. If you are running multiple containers you will find
-multiple cgroups trees under the ``singularity`` directory.
+memory. This example assumes that there is only one running container.
+If you are running multiple containers you will find multiple cgroups
+trees under the ``singularity`` directory.
 
-.. code-block:: none
+.. code::
 
-  # cgroups v1
-  $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
-    524288000
+   # cgroups v1
+   $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
+     524288000
 
-  # cgroups v2 - note translation of memory.limit_in_bytes -> memory.max
-  $ cat /sys/fs/cgroup/singularity/*/memory.max
-  524288000
-
+   # cgroups v2 - note translation of memory.limit_in_bytes -> memory.max
+   $ cat /sys/fs/cgroup/singularity/*/memory.max
+   524288000
 
 Limiting CPU
 ------------
@@ -561,111 +551,108 @@ specified in the ``[cpu]`` section of the TOML file.
 
 **shares**
 
-This corresponds to a ratio versus other cgroups with cpu
-shares. Usually the default value is ``1024``. That means if you want
-to allow to use 50% of a single CPU, you will set ``512`` as value.
+This corresponds to a ratio versus other cgroups with cpu shares.
+Usually the default value is ``1024``. That means if you want to allow
+to use 50% of a single CPU, you will set ``512`` as value.
 
-.. code-block:: none
+.. code::
 
-  [cpu]
-      shares = 512
+   [cpu]
+       shares = 512
 
-A cgroup can get more than its share of CPU if there are enough idle
-CPU cycles available in the system, due to the work conserving nature
-of the scheduler, so a contained process can consume all CPU cycles
-even with a ratio of 50%. The ratio is only applied when two or more
-processes conflicts with their needs of CPU cycles.
+A cgroup can get more than its share of CPU if there are enough idle CPU
+cycles available in the system, due to the work conserving nature of the
+scheduler, so a contained process can consume all CPU cycles even with a
+ratio of 50%. The ratio is only applied when two or more processes
+conflicts with their needs of CPU cycles.
 
 **quota/period**
 
 You can enforce hard limits on the CPU cycles a cgroup can consume, so
 contained processes can't use more than the amount of CPU time set for
 the cgroup. ``quota`` allows you to configure the amount of CPU time
-that a cgroup can use per period. The default is 100ms (100000us). So
-if you want to limit amount of CPU time to 20ms during period of
-100ms:
+that a cgroup can use per period. The default is 100ms (100000us). So if
+you want to limit amount of CPU time to 20ms during period of 100ms:
 
-.. code-block:: none
+.. code::
 
-  [cpu]
-      period = 100000
-      quota = 20000
+   [cpu]
+       period = 100000
+       quota = 20000
 
 **cpus/mems**
 
 You can also restrict access to specific CPUs (cores) and associated
 memory nodes by using ``cpus/mems`` fields:
 
-.. code-block:: none
+.. code::
 
-  [cpu]
-      cpus = "0-1"
-      mems = "0-1"
+   [cpu]
+       cpus = "0-1"
+       mems = "0-1"
 
 Where container has limited access to CPU 0 and CPU 1.
 
 .. note::
 
-  It's important to set identical values for both ``cpus`` and ``mems``.
-
+   It's important to set identical values for both ``cpus`` and
+   ``mems``.
 
 Limiting IO
 -----------
 
-To control block device I/O, applying limits to competing container,
-use the ``[blockIO]`` section of the TOML file:
+To control block device I/O, applying limits to competing container, use
+the ``[blockIO]`` section of the TOML file:
 
-.. code-block:: none
+.. code::
 
-  [blockIO]
-      weight = 1000
-      leafWeight = 1000
+   [blockIO]
+       weight = 1000
+       leafWeight = 1000
 
-``weight`` and ``leafWeight`` accept values between ``10`` and
-``1000``.
+``weight`` and ``leafWeight`` accept values between ``10`` and ``1000``.
 
 ``weight`` is the default weight of the group on all the devices until
 and unless overridden by a per device rule.
 
-``leafWeight`` relates to weight for the purpose of deciding how
-heavily to weigh tasks in the given cgroup while competing with the
-cgroup's child cgroups.
-
+``leafWeight`` relates to weight for the purpose of deciding how heavily
+to weigh tasks in the given cgroup while competing with the cgroup's
+child cgroups.
 
 To apply limits to specific block devices, you must set configuration
 for specific device major/minor numbers. For example, to override
 ``weight/leafWeight`` for ``/dev/loop0`` and ``/dev/loop1`` block
 devices, set limits for device major 7, minor 0 and 1:
 
-.. code-block:: none
+.. code::
 
-  [blockIO]
-      [[blockIO.weightDevice]]
-          major = 7
-          minor = 0
-          weight = 100
-          leafWeight = 50
-      [[blockIO.weightDevice]]
-          major = 7
-          minor = 1
-          weight = 100
-          leafWeight = 50
+   [blockIO]
+       [[blockIO.weightDevice]]
+           major = 7
+           minor = 0
+           weight = 100
+           leafWeight = 50
+       [[blockIO.weightDevice]]
+           major = 7
+           minor = 1
+           weight = 100
+           leafWeight = 50
 
-You can also limit the IO read/write rate to a specific absolute
-value, e.g. 16MB per second for the ``/dev/loop0`` block device. The
-``rate`` is specified in bytes per second.
+You can also limit the IO read/write rate to a specific absolute value,
+e.g. 16MB per second for the ``/dev/loop0`` block device. The ``rate``
+is specified in bytes per second.
 
-.. code-block:: none
+.. code::
 
-  [blockIO]
-      [[blockIO.throttleReadBpsDevice]]
-          major = 7
-          minor = 0
-          rate = 16777216
-      [[blockIO.throttleWriteBpsDevice]]
-          major = 7
-          minor = 0
-          rate = 16777216
+   [blockIO]
+       [[blockIO.throttleReadBpsDevice]]
+           major = 7
+           minor = 0
+           rate = 16777216
+       [[blockIO.throttleWriteBpsDevice]]
+           major = 7
+           minor = 0
+           rate = 16777216
 
 Other limits
 ------------
@@ -677,34 +664,34 @@ translated to v2 format when applied on a cgroups v1 system.
 
 See
 https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#control-groups
-for information about the available limits. Note that {Singularity}
-uses TOML format for the confiuration file, rather than JSON.
+for information about the available limits. Note that {Singularity} uses
+TOML format for the confiuration file, rather than JSON.
 
 .. _execution_control_list:
 
---------
-ecl.toml
---------
+**********
+ ecl.toml
+**********
 
-The execution control list that can be used to restrict the execution
-of SIF files by signing key is defined here. You can authorize the
+The execution control list that can be used to restrict the execution of
+SIF files by signing key is defined here. You can authorize the
 containers by validating both the location of the SIF file in the
 filesystem and by checking against a list of signing entities.
 
 .. warning::
 
    The ECL configuration applies to SIF container images only. To lock
-   down execution fully you should disable execution of other
-   container types (squashfs/extfs/dir) via the ``singularity.conf``
-   file ``allow container`` settings.
+   down execution fully you should disable execution of other container
+   types (squashfs/extfs/dir) via the ``singularity.conf`` file ``allow
+   container`` settings.
 
-.. code-block:: none
+.. code::
 
-  [[execgroup]]
-    tagname = "group2"
-    mode = "whitelist"
-    dirpath = "/tmp/containers"
-    keyfp = ["7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
+   [[execgroup]]
+     tagname = "group2"
+     mode = "whitelist"
+     dirpath = "/tmp/containers"
+     keyfp = ["7064B1D6EFF01B1262FED3F03581D99FE87EAFD1"]
 
 Only the containers running from and signed with above-mentioned path
 and keys will be authorized to run.
@@ -712,77 +699,73 @@ and keys will be authorized to run.
 Three possible list modes you can choose from:
 
 **Whitestrict**: The SIF must be signed by *ALL* of the keys
- mentioned.
+   mentioned.
 
-**Whitelist**: As long as the SIF is signed by one or more of the
-keys, the container is allowed to run.
+**Whitelist**: As long as the SIF is signed by one or more of the keys,
+the container is allowed to run.
 
 **Blacklist**: Only the containers whose keys are not mentioned in the
 group are allowed to run.
 
 .. note::
 
-    The ECL checks will use the new signature format introduced in
-    {Singularity} 3.6.0. Containers signed with older versions of Singularity
-    {Singularity} will not pass ECL checks.
+   The ECL checks will use the new signature format introduced in
+   {Singularity} 3.6.0. Containers signed with older versions of
+   Singularity {Singularity} will not pass ECL checks.
 
-    To temporarily permit the use of legacy insecure signatures, set
-    ``legacyinsecure = true`` in ``ecl.toml``.
+   To temporarily permit the use of legacy insecure signatures, set
+   ``legacyinsecure = true`` in ``ecl.toml``.
 
 Managing ECL public keys
 ========================
 
-In {Singularity} 3.6, public keys associated with fingerprints
-specified in ECL rules were required to be present in user's local
-keyring which is not very convenient. {Singularity} 3.7.0 provides a
-mechanism to administrators for managing a global keyring that ECL
-uses during signature verification, for that purpose a ``--global``
-option was added for:
+In {Singularity} 3.6, public keys associated with fingerprints specified
+in ECL rules were required to be present in user's local keyring which
+is not very convenient. {Singularity} 3.7.0 provides a mechanism to
+administrators for managing a global keyring that ECL uses during
+signature verification, for that purpose a ``--global`` option was added
+for:
 
-  * ``singularity key import`` (root user only)
-  * ``singularity key pull`` (root user only)
-  * ``singularity key remove`` (root user only)
-  * ``singularity key export``
-  * ``singularity key list``
+   -  ``singularity key import`` (root user only)
+   -  ``singularity key pull`` (root user only)
+   -  ``singularity key remove`` (root user only)
+   -  ``singularity key export``
+   -  ``singularity key list``
 
 .. note::
 
-    For security reasons, it is not possible to import private keys
-    into this global keyring because it must be accessible by users
-    and is stored in the file
-    ``SYSCONFDIR/singularity/global-pgp-public``.
+   For security reasons, it is not possible to import private keys into
+   this global keyring because it must be accessible by users and is
+   stored in the file ``SYSCONFDIR/singularity/global-pgp-public``.
 
 .. _gpu_library_configuration:
 
--------------------------
-GPU Library Configuration
--------------------------
+***************************
+ GPU Library Configuration
+***************************
 
-When a container includes a GPU enabled application, {Singularity}
-(with the ``--nv`` or ``--rocm`` options) can properly inject the
-required Nvidia or AMD GPU driver libraries into the container, to
-match the host's kernel. The GPU ``/dev`` entries are provided in
-containers run with ``--nv`` or ``--rocm`` even if the ``--contain``
-option is used to restrict the in-container device tree.
+When a container includes a GPU enabled application, {Singularity} (with
+the ``--nv`` or ``--rocm`` options) can properly inject the required
+Nvidia or AMD GPU driver libraries into the container, to match the
+host's kernel. The GPU ``/dev`` entries are provided in containers run
+with ``--nv`` or ``--rocm`` even if the ``--contain`` option is used to
+restrict the in-container device tree.
 
 Compatibility between containerized CUDA/ROCm/OpenCL applications and
 host drivers/libraries is dependent on the versions of the GPU compute
 frameworks that were used to build the applications. Compatibility and
-usage information is discussed in the `GPU Support` section of the
-`user guide
-<\{userdocs\}>`__
-
+usage information is discussed in the `GPU Support` section of the `user
+guide <{userdocs}>`__
 
 NVIDIA GPUs / CUDA
 ==================
 
 The ``nvliblist.conf`` configuration file is used to specify libraries
-and executables that need to be injected into the container when
-running {Singularity} with the ``--nv`` Nvidia GPU support option. The
-provided ``nvliblist.conf`` is suitable for CUDA 11, but may need to
-be modified if you need to include additional libraries, or further
-libraries are added to newer versions of the Nvidia driver/CUDA
-distribution.
+and executables that need to be injected into the container when running
+{Singularity} with the ``--nv`` Nvidia GPU support option. The provided
+``nvliblist.conf`` is suitable for CUDA 11, but may need to be modified
+if you need to include additional libraries, or further libraries are
+added to newer versions of the Nvidia driver/CUDA distribution.
 
 When adding new entries to ``nvliblist.conf`` use the bare filename of
 executables, and the ``xxxx.so`` form of libraries. Libraries are
@@ -794,15 +777,15 @@ Experimental nvidia-container-cli Support
 
 The `nvidia-container-cli
 <https://github.com/NVIDIA/libnvidia-container>`_ tool is Nvidia's
-officially support method for configuring containers to use a GPU. It
-is targeted at OCI container runtimes.
+officially support method for configuring containers to use a GPU. It is
+targeted at OCI container runtimes.
 
-{Singularity} 3.9 introduces an experimental ``--nvccli`` option,
-which will call out to ``nvidia-container-cli`` for container GPU
-setup, rather than use the ``nvliblist.conf`` approach.
+{Singularity} 3.9 introduces an experimental ``--nvccli`` option, which
+will call out to ``nvidia-container-cli`` for container GPU setup,
+rather than use the ``nvliblist.conf`` approach.
 
-To use ``--nvccli`` a ``nvidia-container-cli`` binary must
-be present on the host. The binary that is run is controlled by the
+To use ``--nvccli`` a ``nvidia-container-cli`` binary must be
+present on the host. The binary that is run is controlled by the
 ``nvidia-container-cli`` directive in ``singularity.conf``. During
 installation of {Singularity}, the ``./mconfig`` step will set the
 correct value in ``singularity.conf`` if ``nvidia-container-cli`` is
@@ -811,15 +794,15 @@ empty, {Singularity} will look for the binary on ``$PATH`` at runtime.
 
 .. note::
 
-   To prevent use of ``nvidia-container-cli`` via the ``--nvccli``
-   flag, you may set ``nvidia-container-cli path`` to ``/bin/false``
-   in ``singularity.conf``.
+   To prevent use of ``nvidia-container-cli`` via the ``--nvccli`` flag,
+   you may set ``nvidia-container-cli path`` to ``/bin/false`` in
+   ``singularity.conf``.
 
 For security reasons, ``nvidia-container-cli`` cannot be used with privileged mode
-in a setuid installation of {Singularity}, it can only be used unprivileged.  The
-operations performed by ``nvidia-container-cli`` are broadly similar
-to those which {Singularity} carries out when setting up a GPU
-container from ``nvliblist.conf``.
+in a setuid installation of {Singularity}, it can only be used unprivileged. The
+operations performed by ``nvidia-container-cli`` are broadly similar to
+those which {Singularity} carries out when setting up a GPU container
+from ``nvliblist.conf``.
 
 AMD Radeon GPUs / ROCm
 ======================
@@ -827,8 +810,8 @@ AMD Radeon GPUs / ROCm
 The ``rocmliblist.conf`` file is used to specify libraries and
 executables that need to be injected into the container when running
 {Singularity} with the ``--rocm`` Radeon GPU support option. The
-provided ``rocmliblist.conf`` is suitable for ROCm 4.0, but may need
-to modified if you need to include additional libraries, or further
+provided ``rocmliblist.conf`` is suitable for ROCm 4.0, but may need to
+modified if you need to include additional libraries, or further
 libraries are added to newer versions of the ROCm distribution.
 
 When adding new entries to ``rocmlist.conf`` use the bare filename of
@@ -845,160 +828,154 @@ information.
 
 Binaries are found by searching ``$PATH``:
 
-.. code-block:: none
+.. code::
 
-    # put binaries here
-    # In shared environments you should ensure that permissions on these files
-    # exclude writing by non-privileged users.
-    rocm-smi
-    rocminfo
+   # put binaries here
+   # In shared environments you should ensure that permissions on these files
+   # exclude writing by non-privileged users.
+   rocm-smi
+   rocminfo
 
-Libraries should be specified without version information,
-i.e. ``libname.so``, and are resolved using ``ldconfig``.
+Libraries should be specified without version information, i.e.
+``libname.so``, and are resolved using ``ldconfig``.
 
-.. code-block:: none
+.. code::
 
    # put libs here (must end in .so)
    libamd_comgr.so
    libcomgr.so
    libCXLActivityLogger.so
 
-If you receive warnings that binaries or libraries are not found,
-ensure that they are in a system path (binaries), or available in paths
+If you receive warnings that binaries or libraries are not found, ensure
+that they are in a system path (binaries), or available in paths
 configured in ``/etc/ld.so.conf`` (libraries).
 
-
----------------
-capability.json
----------------
+*****************
+ capability.json
+*****************
 
 .. warning::
 
-     It is extremely important to recognize that **granting users
-     Linux capabilities with the** ``capability`` **command group is
-     usually identical to granting those users root level access on
-     the host system**. Most if not all capabilities will allow users
-     to "break out" of the container and become root on the host. This
-     feature is targeted toward special use cases (like cloud-native
-     architectures) where an admin/developer might want to limit the
-     attack surface within a container that normally runs as root.
-     This is not a good option in multi-tenant HPC environments where
-     an admin wants to grant a user special privileges within a
-     container. For that and similar use cases, the :ref:`fakeroot
-     feature <fakeroot>` is a better option.
+   It is extremely important to recognize that **granting users Linux
+   capabilities with the** ``capability`` **command group is usually
+   identical to granting those users root level access on the host
+   system**. Most if not all capabilities will allow users to "break
+   out" of the container and become root on the host. This feature is
+   targeted toward special use cases (like cloud-native architectures)
+   where an admin/developer might want to limit the attack surface
+   within a container that normally runs as root. This is not a good
+   option in multi-tenant HPC environments where an admin wants to grant
+   a user special privileges within a container. For that and similar
+   use cases, the :ref:`fakeroot feature <fakeroot>` is a better option.
 
-{Singularity} provides full support for admins to grant and revoke
-Linux capabilities on a user or group basis. The ``capability.json``
-file is maintained by {Singularity} in order to manage these
-capabilities. The ``capability`` command group allows you to ``add``,
-``drop``, and ``list`` capabilities for users and groups.
+{Singularity} provides full support for admins to grant and revoke Linux
+capabilities on a user or group basis. The ``capability.json`` file is
+maintained by {Singularity} in order to manage these capabilities. The
+``capability`` command group allows you to ``add``, ``drop``, and
+``list`` capabilities for users and groups.
 
-For example, let us suppose that we have decided to grant a user
-(named ``pinger``) capabilities to open raw sockets so that they can
-use ``ping`` in a container where the binary is controlled via
-capabilities.
+For example, let us suppose that we have decided to grant a user (named
+``pinger``) capabilities to open raw sockets so that they can use
+``ping`` in a container where the binary is controlled via capabilities.
 
 To do so, we would issue a command such as this:
 
-.. code-block:: none
+.. code::
 
-    $ sudo singularity capability add --user pinger CAP_NET_RAW
+   $ sudo singularity capability add --user pinger CAP_NET_RAW
 
 This means the user ``pinger`` has just been granted permissions
 (through Linux capabilities) to open raw sockets within {Singularity}
 containers.
 
-We can check that this change is in effect with the ``capability
-list`` command.
+We can check that this change is in effect with the ``capability list``
+command.
 
-.. code-block:: none
+.. code::
 
-    $ sudo singularity capability list --user pinger
-    CAP_NET_RAW
+   $ sudo singularity capability list --user pinger
+   CAP_NET_RAW
 
-To take advantage of this new capability, the user ``pinger`` must
-also request the capability when executing a container with the
-``--add-caps`` flag.  ``pinger`` would need to run a command like
-this:
+To take advantage of this new capability, the user ``pinger`` must also
+request the capability when executing a container with the
+``--add-caps`` flag. ``pinger`` would need to run a command like this:
 
-.. code-block:: none
+.. code::
 
-    $ singularity exec --add-caps CAP_NET_RAW \
-      library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-    64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
+   $ singularity exec --add-caps CAP_NET_RAW \
+     library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+   64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
 
-    --- 8.8.8.8 ping statistics ---
-    1 packets transmitted, 1 received, 0% packet loss, time 0ms
-    rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
+   --- 8.8.8.8 ping statistics ---
+   1 packets transmitted, 1 received, 0% packet loss, time 0ms
+   rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
 
-If we decide that it is no longer necessary to allow the user
-``pinger`` to open raw sockets within {Singularity} containers, we can
-revoke the appropriate Linux capability like so:
+If we decide that it is no longer necessary to allow the user ``pinger``
+to open raw sockets within {Singularity} containers, we can revoke the
+appropriate Linux capability like so:
 
-.. code-block:: none
+.. code::
 
-    $ sudo singularity capability drop --user pinger CAP_NET_RAW
+   $ sudo singularity capability drop --user pinger CAP_NET_RAW
 
 Now if ``pinger`` tries to use ``CAP_NET_RAW``, {Singularity} will not
-give the capability to the container and ``ping`` will fail to create
-a socket:
+give the capability to the container and ``ping`` will fail to create a
+socket:
 
-.. code-block:: none
+.. code::
 
-    $ singularity exec --add-caps CAP_NET_RAW \
-      library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    WARNING: not authorized to add capability: CAP_NET_RAW
-    ping: socket: Operation not permitted
+   $ singularity exec --add-caps CAP_NET_RAW \
+     library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   WARNING: not authorized to add capability: CAP_NET_RAW
+   ping: socket: Operation not permitted
 
 The ``capability add`` and ``drop`` subcommands will also accept the
 case insensitive keyword ``all`` to grant or revoke all Linux
 capabilities to a user or group.
 
 For more information about individual Linux capabilities check out the
-`man pages
-<http://man7.org/linux/man-pages/man7/capabilities.7.html>`_ or use
-the ``capability avail`` command to output available capabilities with
-a description of their behaviors.
+`man pages <http://man7.org/linux/man-pages/man7/capabilities.7.html>`_
+or use the ``capability avail`` command to output available capabilities
+with a description of their behaviors.
 
-----------------
-seccomp-profiles
-----------------
+******************
+ seccomp-profiles
+******************
 
 Secure Computing (seccomp) Mode is a feature of the Linux kernel that
 allows an administrator to filter system calls being made from a
 container. Profiles made up of allowed and restricted calls can be
-passed to different containers.  *Seccomp* provides more control than
-*capabilities* alone, giving a smaller attack surface for an attacker
-to work from within a container.
+passed to different containers. *Seccomp* provides more control than
+*capabilities* alone, giving a smaller attack surface for an attacker to
+work from within a container.
 
 You can set the default action with ``defaultAction`` for a non-listed
 system call. Example: ``SCMP_ACT_ALLOW`` filter will allow all the
 system calls if it matches the filter rule and you can set it to
-``SCMP_ACT_ERRNO`` which will have the thread receive a return value
-of *errno* if it calls a system call that matches the filter rule.
-The file is formatted in a way that it can take a list of additional
-system calls for different architecture and {Singularity} will
-automatically take syscalls related to the current architecture where
-it's been executed.  The ``include``/``exclude``-> ``caps`` section
-will include/exclude the listed system calls if the user has the
-associated capability.
+``SCMP_ACT_ERRNO`` which will have the thread receive a return value of
+*errno* if it calls a system call that matches the filter rule. The file
+is formatted in a way that it can take a list of additional system calls
+for different architecture and {Singularity} will automatically take
+syscalls related to the current architecture where it's been executed.
+The ``include``/``exclude``-> ``caps`` section will include/exclude the
+listed system calls if the user has the associated capability.
 
 Use the ``--security`` option to invoke the container like:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity shell --security seccomp:/home/david/my.json my_container.sif
+   $ sudo singularity shell --security seccomp:/home/david/my.json my_container.sif
 
 For more insight into security options, network options, cgroups,
 capabilities, etc, please check the `Userdocs
-<\{userdocs\}>`_ and it's
+<{userdocs}>`_ and it's
 `Appendix
-<\{userdocs\}/appendix.html>`_.
+<{userdocs}/appendix.html>`_.
 
-------------
-remote.yaml
-------------
+*************
+ remote.yaml
+*************
 
 System-wide remote endpoints are defined in a configuration file
 typically located at ``/usr/local/etc/singularity/remote.yaml`` (this
@@ -1012,39 +989,37 @@ Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/home>`_ to enable users to `Create
 <https://cloud.sylabs.io/builder>`_, `Secure
 <https://cloud.sylabs.io/keystore?sign=true>`_, and `Share
-<https://cloud.sylabs.io/library/guide#create>`_ their container
-images with others.
+<https://cloud.sylabs.io/library/guide#create>`_ their container images
+with others.
 
 {Singularity} allows users to login to an account on the Sylabs Cloud,
 or configure {Singularity} to use an API compatable container service
-such as a local installation of {Singularity} Enterprise, which
-provides an on-premise private Container Library, Remote Builder and
-Key Store.
+such as a local installation of {Singularity} Enterprise, which provides
+an on-premise private Container Library, Remote Builder and Key Store.
 
 .. note::
 
-   A fresh installation of {Singularity} is automatically configured
-   to connect to the public `Sylabs Cloud <https://cloud.sylabs.io>`__
+   A fresh installation of {Singularity} is automatically configured to
+   connect to the public `Sylabs Cloud <https://cloud.sylabs.io>`__
    services.
 
 **Examples**
 
+Use the ``remote`` command group with the ``--global`` flag to create a
+system-wide remote endpoint:
 
-Use the ``remote`` command group with the ``--global`` flag to create
-a system-wide remote endpoint:
+.. code::
 
-.. code-block:: none
-
-    $ sudo singularity remote add --global company-remote https://enterprise.example.com
-    INFO:    Remote "company-remote" added.
-    INFO:    Global option detected. Will not automatically log into remote.
+   $ sudo singularity remote add --global company-remote https://enterprise.example.com
+   INFO:    Remote "company-remote" added.
+   INFO:    Global option detected. Will not automatically log into remote.
 
 Conversely, to remove a system-wide endpoint:
 
-.. code-block:: none
+.. code::
 
-    $ sudo singularity remote remove --global company-remote
-    INFO:    Remote "company-remote" removed.
+   $ sudo singularity remote remove --global company-remote
+   INFO:    Remote "company-remote" removed.
 
 .. note::
 
@@ -1057,54 +1032,54 @@ Conversely, to remove a system-wide endpoint:
 Exclusive Endpoint
 ------------------
 
-{Singularity} 3.7 introduces the ability for an administrator to make
-a remote the only usable remote for the system by using the
+{Singularity} 3.7 introduces the ability for an administrator to make a
+remote the only usable remote for the system by using the
 ``--exclusive`` flag:
 
-.. code-block:: none
+.. code::
 
-    $ sudo singularity remote use --exclusive company-remote
-    INFO:    Remote "company-remote" now in use.
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ sudo singularity remote use --exclusive company-remote
+   INFO:    Remote "company-remote" now in use.
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE  INSECURE
-    SylabsCloud     cloud.sylabs.io         NO      YES     NO         NO
-    company-remote  enterprise.example.com  YES     YES     YES        NO
-    myremote        enterprise.example.com  NO      NO      NO         NO
+   NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE  INSECURE
+   SylabsCloud     cloud.sylabs.io         NO      YES     NO         NO
+   company-remote  enterprise.example.com  YES     YES     YES        NO
+   myremote        enterprise.example.com  NO      NO      NO         NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                       GLOBAL  INSECURE  ORDER
-    https://keys.example.com  YES     NO        1*
+   URI                       GLOBAL  INSECURE  ORDER
+   https://keys.example.com  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
 Insecure (HTTP) Endpoints
 -------------------------
 
 From {Singularity} 3.9, if you are using a endpoint that exposes its
-service discovery file over an insecure HTTP connection only, it can
-be added by specifying the ``--insecure`` flag:
+service discovery file over an insecure HTTP connection only, it can be
+added by specifying the ``--insecure`` flag:
 
-.. code-block::
+.. code::
 
    $ sudo singularity remote add --global --insecure test http://test.example.com
    INFO:    Remote "test" added.
    INFO:    Global option detected. Will not automatically log into remote.
 
 This flag controls HTTP vs HTTPS for service discovery only. The
-protocol used to access individual library, build and keyservice URLs
-is set by the service discovery file.
+protocol used to access individual library, build and keyservice URLs is
+set by the service discovery file.
 
 Additional Information
 ----------------------
 
 For more details on the ``remote`` command group and managing remote
 endpoints, please check the `Remote Userdocs
-<\{userdocs\}/endpoint.html>`_.
+<{userdocs}/endpoint.html>`_.
 
 Keyserver Configuration
 =======================
@@ -1112,9 +1087,9 @@ Keyserver Configuration
 By default, {Singularity} will use the keyserver correlated to the
 active cloud service endpoint. This behavior can be changed or
 supplemented via the ``add-keyserver`` and ``remove-keyserver``
-commands. These commands allow an administrator to create a global
-list of key servers used to verify container signatures by default.
+commands. These commands allow an administrator to create a global list
+of key servers used to verify container signatures by default.
 
 For more details on the ``remote`` command group and managing
 keyservers, please check the `Remote Userdocs
-<\{userdocs\}/endpoint.html>`_.
+<{userdocs}/endpoint.html>`_.

--- a/index.rst
+++ b/index.rst
@@ -1,15 +1,15 @@
-===========
-Admin Guide
-===========
+#############
+ Admin Guide
+#############
 
 Welcome to the {Singularity} Admin Guide!
 
 This guide aims to cover installation instructions, configuration
-detail, and other topics important to system adminstrators working
-with {Singularity}.
+detail, and other topics important to system adminstrators working with
+{Singularity}.
 
 See the `user guide
-<\{userdocs\}>`__ for more
+<{userdocs}>`__ for more
 information about how to use {Singularity}.
 
 .. toctree::

--- a/installation.rst
+++ b/installation.rst
@@ -1,106 +1,113 @@
 .. _installation:
 
-########################
-Installing {Singularity}
-########################
+##########################
+ Installing {Singularity}
+##########################
 
 This section will guide you through the process of installing
-{Singularity} {InstallationVersion} via several different
-methods. (For instructions on installing earlier versions of
-{Singularity} please see `earlier versions of the docs
-<https://singularity.hpcng.org/docs/>`_.)
+{Singularity} {InstallationVersion} via several different methods. (For
+instructions on installing earlier versions of {Singularity} please see
+`earlier versions of the docs <https://singularity.hpcng.org/docs/>`_.)
 
-=====================
-Installation on Linux
-=====================
+***********************
+ Installation on Linux
+***********************
 
 {Singularity} can be installed on any modern Linux distribution, on
 bare-metal or inside a Virtual Machine. Nested installations inside
 containers are not recommended, and require the outer container to be
 run with full privilege.
 
--------------------
 System Requirements
--------------------
+===================
 
 {Singularity} requires ~140MiB disk space once compiled and installed.
 
-There are no specific CPU or memory requirements at runtime, though
-2GB of RAM is recommended when building from source.
+There are no specific CPU or memory requirements at runtime, though 2GB
+of RAM is recommended when building from source.
 
 Full functionality of {Singularity} requires that the kernel supports:
 
- - **OverlayFS mounts** - (minimum kernel >=3.18) Required for full
-   flexiblity in bind mounts to containers, and to support persistent
-   overlays for writable containers.
- - **Unprivileged user namespaces** - (minimum kernel >=3.8, >=3.18
-   recommended) Required to run containers without root or setuid
-   privilege.
+   -  **OverlayFS mounts** - (minimum kernel >=3.18) Required for full
+      flexiblity in bind mounts to containers, and to support persistent
+      overlays for writable containers.
+
+   -  **Unprivileged user namespaces** - (minimum kernel >=3.8, >=3.18
+      recommended) Required to run containers without root or setuid
+      privilege.
 
 External Binaries
-=================
+-----------------
 
 Singularity depends on a number of external binaries for full
-functionality. From {Singularity} 3.9, the methods that are used to
-find these binaries have been standardized as below.
+functionality. From {Singularity} 3.9, the methods that are used to find
+these binaries have been standardized as below.
 
 Configurable Paths
-------------------
+^^^^^^^^^^^^^^^^^^
 
 The following binaries are found on ``$PATH`` during build time when
 ``./mconfig`` is run, and their location is added to the
 ``singularity.conf`` configuration file. At runtime this configured
 location is used. To specify an alternate executable, change the
-relevant path entry in ``singularity.conf``. If the
-``singularity.conf`` entry is left blank, then ``$PATH`` will be
-searched at runtime.
+relevant path entry in ``singularity.conf``. If the ``singularity.conf``
+entry is left blank, then ``$PATH`` will be searched at runtime.
 
-* ``cryptsetup`` version 2 with kernel LUKS2 support is required for
-  building or executing encrypted containers.
-* ``go`` is required to compile plugins, and must be an identical
-  version as that used to build {Singularity}.
-* ``ldconfig`` is used to resolve library locations / symlinks when
-  using the ``-nv`` or ``--rocm`` GPU support.
-* ``mksquashfs`` from squashfs-tools 4.3+ is used to create the
-  squashfs container filesystem that is embedded into SIF container
-  images. The ``mksquashfs procs`` and ``mksquashfs mem`` directives
-  in ``singularity.conf`` can be used to control its resource usage.
-* ``unsquashfs`` from squashfs-tools 4.3+ is used to extract the
-  squashfs container filesystem from a SIF file when necessary.
-* ``nvidia-container-cli`` is used to configure a container for Nvidia
-  GPU / CUDA support when running with the experimental ``--nvccli``
-  option.
+-  ``cryptsetup`` version 2 with kernel LUKS2 support is required for
+   building or executing encrypted containers.
+
+-  ``go`` is required to compile plugins, and must be an identical
+   version as that used to build {Singularity}.
+
+-  ``ldconfig`` is used to resolve library locations / symlinks when
+   using the ``-nv`` or ``--rocm`` GPU support.
+
+-  ``mksquashfs`` from squashfs-tools 4.3+ is used to create the
+   squashfs container filesystem that is embedded into SIF container
+   images. The ``mksquashfs procs`` and ``mksquashfs mem`` directives in
+   ``singularity.conf`` can be used to control its resource usage.
+
+-  ``unsquashfs`` from squashfs-tools 4.3+ is used to extract the
+   squashfs container filesystem from a SIF file when necessary.
+
+-  ``nvidia-container-cli`` is used to configure a container for Nvidia
+   GPU / CUDA support when running with the experimental ``--nvccli``
+   option.
 
 Searching $PATH
----------------
+^^^^^^^^^^^^^^^
 
-The following standard utilities are always found by searching
-``$PATH`` at runtime:
+The following standard utilities are always found by searching ``$PATH``
+at runtime:
 
-* ``true``
-* ``mkfs.ext3`` is used to create overlay images.
-* ``cp``
-* ``dd``
-* ``newuidmap`` and ``newgidmap`` are distribution provided setuid
-  binaries used to configure subuid/gid mappings forr ``--fakeroot``
-  in non-setuid installs.
+-  ``true``
+
+-  ``mkfs.ext3`` is used to create overlay images.
+
+-  ``cp``
+
+-  ``dd``
+
+-  ``newuidmap`` and ``newgidmap`` are distribution provided setuid
+   binaries used to configure subuid/gid mappings forr ``--fakeroot`` in
+   non-setuid installs.
 
 Bootstrap Utilities
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 The following utilities are required to bootstrap containerized
 distributions using their native tooling:
 
-* ``mount``, ``umount``, ``pacstrap`` for Arch Linux.
-* ``mount``, ``umount``, ``mknod``, ``debootstrap`` for Debian based
-  distributions.
-* ``dnf`` or ``yum``, ``rpm``, ``curl`` for EL derived RPM based
-  distributions.
-* ``uname``, ``zypper``, ``SUSEConnect`` for SLES derived RPM based
-  distributions.
+-  ``mount``, ``umount``, ``pacstrap`` for Arch Linux.
+-  ``mount``, ``umount``, ``mknod``, ``debootstrap`` for Debian based
+   distributions.
+-  ``dnf`` or ``yum``, ``rpm``, ``curl`` for EL derived RPM based
+   distributions.
+-  ``uname``, ``zypper``, ``SUSEConnect`` for SLES derived RPM based
+   distributions.
 
 Non-standard ldconfig / Nix & Guix Environments
-===============================================
+-----------------------------------------------
 
 If {Singularity} is installed under a package manager such as Nix or
 Guix, but on top of a standard Linux distribution (e.g. CentOS or
@@ -112,24 +119,27 @@ libraries installed from host packages.
 To allow {Singularity} to locate the host (i.e. CentOS / Debian) GPU
 libraries correctly, set ``ldconfig path`` in ``singularity.conf`` to
 point to the host ``ldconfig``. I.E. it should be set to
-``/sbin/ldconfig`` or ``/sbin/ldconfig.real`` rather than a Nix or
-Guix related path.
+``/sbin/ldconfig`` or ``/sbin/ldconfig.real`` rather than a Nix or Guix
+related path.
 
 Filesystem support / limitations
-================================
+--------------------------------
 
 {Singularity} supports most filesystems, but there are some limitations
 when installing {Singularity} on, or running containers from, common
 parallel / network filesystems. In general:
 
- - We strongly recommend installing {Singularity} on local disk on each
-   compute node.
- - If {Singularity} is installed to a network location, a
-   ``--localstatedir`` should be provided on each node, and Singularity
-   configured to use it.
- - The ``--localstatedir`` filesystem should support overlay mounts.
- - ``TMPDIR`` / ``SINGULARITY_TMPDIR`` should be on a local filesystem
-   wherever possible.
+   -  We strongly recommend installing {Singularity} on local disk on
+      each compute node.
+
+   -  If {Singularity} is installed to a network location, a
+      ``--localstatedir`` should be provided on each node, and
+      Singularity configured to use it.
+
+   -  The ``--localstatedir`` filesystem should support overlay mounts.
+
+   -  ``TMPDIR`` / ``SINGULARITY_TMPDIR`` should be on a local
+      filesystem wherever possible.
 
 .. note::
 
@@ -137,75 +147,77 @@ parallel / network filesystems. In general:
    ``--localstatedir my/dir`` as an option when you configure your
    {Singularity} build with ``./mconfig``.
 
-   Disk usage at the ``--localstatedir`` location is neglible
-   (<1MiB). The directory is used as a location to mount the container
-   root filesystem, overlays, bind mounts etc. that construct the
-   runtime view of a container. You will not see these mounts from a
-   host shell, as they are made in a separate mount namespace.
-
+   Disk usage at the ``--localstatedir`` location is neglible (<1MiB).
+   The directory is used as a location to mount the container root
+   filesystem, overlays, bind mounts etc. that construct the runtime
+   view of a container. You will not see these mounts from a host shell,
+   as they are made in a separate mount namespace.
 
 Overlay support
----------------
+^^^^^^^^^^^^^^^
 
 Various features of {Singularity}, such as the ``--writable-tmpfs`` and
 ``--overlay``, options use the Linux ``overlay`` filesystem driver to
-construct a container root filesystem that combines files from
-different locations. Not all filesystems can be used with the
-``overlay`` driver, so when containers are run from these filesystems
-some {Singularity} features may not be available.
+construct a container root filesystem that combines files from different
+locations. Not all filesystems can be used with the ``overlay`` driver,
+so when containers are run from these filesystems some {Singularity}
+features may not be available.
 
 Overlay support has two aspects:
 
-  - ``lowerdir`` support for a filesystem allows a directory on that
-    filesystem to act as the 'base' of a container. A filesystem must
-    support overlay ``lowerdir`` for you be able to run a Singularity
-    sandbox container on it, while using functionality such as
-    ``--writable-tmpfs`` / ``--overlay``.
-  - ``upperdir`` support for a filesystem allows a directory on that
-    filesystem to be merged on top of a ``lowerdir`` to construct a
-    container. If you use the ``--overlay`` option to overlay a
-    directory onto a container, then the filesystem holding the
-    overlay directory must support ``upperdir``.
+   -  ``lowerdir`` support for a filesystem allows a directory on that
+      filesystem to act as the 'base' of a container. A filesystem must
+      support overlay ``lowerdir`` for you be able to run a Singularity
+      sandbox container on it, while using functionality such as
+      ``--writable-tmpfs`` / ``--overlay``.
+
+   -  ``upperdir`` support for a filesystem allows a directory on that
+      filesystem to be merged on top of a ``lowerdir`` to construct a
+      container. If you use the ``--overlay`` option to overlay a
+      directory onto a container, then the filesystem holding the
+      overlay directory must support ``upperdir``.
 
 Note that any overlay limitations mainly apply to sandbox (directory)
-containers only. A SIF container is mounted into the
-``--localstatedir`` location, which should generally be on a local
-filesystem that supports overlay.
-
+containers only. A SIF container is mounted into the ``--localstatedir``
+location, which should generally be on a local filesystem that supports
+overlay.
 
 Fakeroot / (sub)uid/gid mapping
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When {Singularity} is run using the :ref:`fakeroot <fakeroot>` option it
-creates a user namespace for the container, and UIDs / GIDs in that
-user namepace are mapped to different host UID / GIDs.
+creates a user namespace for the container, and UIDs / GIDs in that user
+namepace are mapped to different host UID / GIDs.
 
-Most local filesystems (ext4/xfs etc.) support this uid/gid mapping in
-a user namespace.
+Most local filesystems (ext4/xfs etc.) support this uid/gid mapping in a
+user namespace.
 
 Most network filesystems (NFS/Lustre/GPFS etc.) *do not* support this
-uid/gid mapping in a user namespace. Because the fileserver is not
-aware of the mappings it will deny many operations, with 'permission
-denied' errors. This is currently a generic problem for rootless
-container runtimes.
+uid/gid mapping in a user namespace. Because the fileserver is not aware
+of the mappings it will deny many operations, with 'permission denied'
+errors. This is currently a generic problem for rootless container
+runtimes.
 
 {Singularity} cache / atomic rename
------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 {Singularity} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
-created at ``$HOME/.singularity/cache`` by default. The location of
-the cache can be changed by setting the ``SINGULARITY_CACHEDIR``
-environment variable.
+created at ``$HOME/.singularity/cache`` by default. The location of the
+cache can be changed by setting the ``SINGULARITY_CACHEDIR`` environment
+variable.
 
 The directory used for ``SINGULARITY_CACHEDIR`` should be:
 
- - A unique location for each user. Permissions are set on the cache
-   so that private images cached for one user are not exposed to
-   another. This means that ``SINGULARITY_CACHEDIR`` cannot be shared.
- - Located on a filesystem with sufficient space for the number and
-   size of container images anticipated.
- - Located on a filesystem that supports atomic rename, if possible.
+   -  A unique location for each user. Permissions are set on the cache
+      so that private images cached for one user are not exposed to
+      another. This means that ``SINGULARITY_CACHEDIR`` cannot be
+      shared.
+
+   -  Located on a filesystem with sufficient space for the number and
+      size of container images anticipated.
+
+   -  Located on a filesystem that supports atomic rename, if possible.
 
 In {Singularity} version 3.6 and above the cache is concurrency safe.
 Parallel runs of {Singularity} that would create overlapping cache
@@ -220,78 +232,80 @@ atomic to a single client, not across systems accessing the same NFS
 share.
 
 If you are not certain that your ``$HOME`` or ``SINGULARITY_CACHEDIR``
-filesytems support atomic rename, do not run ``singularity`` in
-parallel using remote container URLs. Instead use ``singularity pull``
-to create a local SIF image, and then run this SIF image in a parallel
-step. An alternative is to use the ``--disable-cache`` option, but
-this will result in each {Singularity} instance independently fetching
-the container from the remote source, into a temporary location.
-
+filesytems support atomic rename, do not run ``singularity`` in parallel
+using remote container URLs. Instead use ``singularity pull`` to create
+a local SIF image, and then run this SIF image in a parallel step. An
+alternative is to use the ``--disable-cache`` option, but this will
+result in each {Singularity} instance independently fetching the
+container from the remote source, into a temporary location.
 
 NFS
----
+^^^
 
 NFS filesystems support overlay mounts as a ``lowerdir`` only, and do
 not support user-namespace (sub)uid/gid mapping.
 
- - Containers run from SIF files located on an NFS filesystem do not
-   have restrictions.
- - You cannot use ``--overlay mynfsdir/`` to overlay a directory onto
-   a container when the overlay (upperdir) directory is on an NFS
-   filesystem.
- - When using ``--fakeroot`` to build or run a container, your
-   ``TMPDIR`` / ``SINGULARITY_TMPDIR`` should not be set to an NFS
-   location.
- - You should not run a sandbox container with ``--fakeroot`` from an
-   NFS location.
+   -  Containers run from SIF files located on an NFS filesystem do not
+      have restrictions.
+
+   -  You cannot use ``--overlay mynfsdir/`` to overlay a directory onto
+      a container when the overlay (upperdir) directory is on an NFS
+      filesystem.
+
+   -  When using ``--fakeroot`` to build or run a container, your
+      ``TMPDIR`` / ``SINGULARITY_TMPDIR`` should not be set to an NFS
+      location.
+
+   -  You should not run a sandbox container with ``--fakeroot`` from an
+      NFS location.
 
 Lustre / GPFS
--------------
+^^^^^^^^^^^^^
 
 Lustre and GPFS do not have sufficient ``upperdir`` or ``lowerdir``
 overlay support for certain {Singularity} features, and do not support
 user-namespace (sub)uid/gid mapping.
 
-  - You cannot use ``-overlay`` or ``--writable-tmpfs`` with a sandbox
-    container that is located on a Lustre or GPFS filesystem. SIF
-    containers on Lustre / GPFS will work correctly with these
-    options.
-  - You cannot use ``--overlay`` to overlay a directory onto a
-    container, when the overlay (upperdir) directory is on a Lustre or
-    GPFS filesystem.
-  - When using ``--fakeroot`` to build or run a container, your
-    ``TMPDIR/SINGULARITY_TMPDIR`` should not be a Lustre or GPFS
-    location.
-  - You should not run a sandbox container with ``--fakeroot`` from a
-    Lustre or GPFS location.
+   -  You cannot use ``-overlay`` or ``--writable-tmpfs`` with a sandbox
+      container that is located on a Lustre or GPFS filesystem. SIF
+      containers on Lustre / GPFS will work correctly with these
+      options.
 
-----------------
+   -  You cannot use ``--overlay`` to overlay a directory onto a
+      container, when the overlay (upperdir) directory is on a Lustre or
+      GPFS filesystem.
+
+   -  When using ``--fakeroot`` to build or run a container, your
+      ``TMPDIR/SINGULARITY_TMPDIR`` should not be a Lustre or GPFS
+      location.
+
+   -  You should not run a sandbox container with ``--fakeroot`` from a
+      Lustre or GPFS location.
+
 Before you begin
-----------------
+================
 
 If you have an earlier version of {Singularity} installed, you should
 :ref:`remove it <remove-an-old-version>` before executing the
-installation commands.  You will also need to install some
-dependencies and install `Go <https://golang.org/>`_.
+installation commands. You will also need to install some dependencies
+and install `Go <https://golang.org/>`_.
 
 .. _install-dependencies:
 
--------------------
 Install from Source
--------------------
+===================
 
-To use the latest version of {Singularity} from GitHub you will need
-to build and install it from source. This may sound daunting, but the
+To use the latest version of {Singularity} from GitHub you will need to
+build and install it from source. This may sound daunting, but the
 process is straightforward, and detailed below:
 
-
 Install Dependencies
-====================
+--------------------
 
 On Red Hat Enterprise Linux or CentOS install the following
 dependencies:
 
-.. code-block:: sh
+.. code:: sh
 
    $ sudo yum update -y && \
         sudo yum groupinstall -y 'Development Tools' && \
@@ -303,32 +317,31 @@ dependencies:
         squashfs-tools \
         cryptsetup
 
-
 On Ubuntu or Debian install the following dependencies:
 
-.. code-block:: sh
+.. code:: sh
 
-    $ sudo apt-get update && sudo apt-get install -y \
-        build-essential \
-        uuid-dev \
-        libgpgme-dev \
-        squashfs-tools \
-        libseccomp-dev \
-        wget \
-        pkg-config \
-        git \
-        cryptsetup-bin
+   $ sudo apt-get update && sudo apt-get install -y \
+       build-essential \
+       uuid-dev \
+       libgpgme-dev \
+       squashfs-tools \
+       libseccomp-dev \
+       wget \
+       pkg-config \
+       git \
+       cryptsetup-bin
 
 .. note::
 
-   You can build {Singularity} (3.5+) without ``cryptsetup``
-   available, but will not be able to use encrypted containers without
-   it installed on your system.
+   You can build {Singularity} (3.5+) without ``cryptsetup`` available,
+   but will not be able to use encrypted containers without it installed
+   on your system.
 
 .. _install-go:
 
 Install Go
-==========
+----------
 
 {Singularity} v3 is written primarily in Go, and you will need Go 1.13
 or above installed to compile it from source.
@@ -340,92 +353,89 @@ This is one of several ways to `install and configure Go
 
    If you have previously installed Go from a download, rather than an
    operating system package, you should remove your ``go`` directory,
-   e.g. ``rm -r /usr/local/go`` before installing a newer
-   version. Extracting a new version of Go over an existing
-   installation can lead to errors when building Go programs, as it
-   may leave old files, which have been removed or replaced in newer
-   versions.
-
+   e.g. ``rm -r /usr/local/go`` before installing a newer version.
+   Extracting a new version of Go over an existing installation can lead
+   to errors when building Go programs, as it may leave old files, which
+   have been removed or replaced in newer versions.
 
 Visit the `Go download page <https://golang.org/dl/>`_ and pick a
 package archive to download. Copy the link address and download with
-wget.  Then extract the archive to ``/usr/local`` (or use other
+wget. Then extract the archive to ``/usr/local`` (or use other
 instructions on go installation page).
 
-.. code-block:: none
+.. code::
 
-    $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
-        wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
-        sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
-        rm go$VERSION.$OS-$ARCH.tar.gz
+   $ export VERSION={GoVersion} OS=linux ARCH=amd64 && \
+       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+       rm go$VERSION.$OS-$ARCH.tar.gz
 
 Then, set up your environment for Go.
 
-.. code-block:: none
+.. code::
 
-    $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
-        echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
-        source ~/.bashrc
+   $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
+       echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
+       source ~/.bashrc
 
 Download {Singularity} from a release
-=====================================
+-------------------------------------
 
 You can download {Singularity} from one of the releases. To see a full
 list, visit `the GitHub release page
-<https://github.com/hpcng/singularity/releases>`_.  After deciding on
-a release to install, you can run the following commands to proceed
-with the installation.
+<https://github.com/hpcng/singularity/releases>`_. After deciding on a
+release to install, you can run the following commands to proceed with
+the installation.
 
-.. code-block:: none
+.. code::
 
-    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-        wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-        tar -xzf singularity-${VERSION}.tar.gz && \
-        cd singularity
+   $ export VERSION={InstallationVersion} && # adjust this as necessary \
+       wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+       tar -xzf singularity-${VERSION}.tar.gz && \
+       cd singularity
 
 Checkout Code from Git
-======================
+----------------------
 
-The following commands will install {Singularity} from the `GitHub
-repo <https://github.com/hpcng/singularity>`_ to ``/usr/local``. This
-method will work for >=v{InstallationVersion}. To install an older
-tagged release see `older versions of the docs
-<https://singularity.hpcng.org/docs/>`_.
+The following commands will install {Singularity} from the `GitHub repo
+<https://github.com/hpcng/singularity>`_ to ``/usr/local``. This method
+will work for >=v{InstallationVersion}. To install an older tagged
+release see `older versions of the docs <https://singularity.hpcng.org/docs/>`_.
 
 When installing from source, you can decide to install from either a
 **tag**, a **release branch**, or from the **master branch**.
 
-- **tag**: GitHub tags form the basis for releases, so installing from
-  a tag is the same as downloading and installing a `specific release
-  <https://github.com/hpcng/singularity/releases>`_.  Tags are
-  expected to be relatively stable and well-tested.
+-  **tag**: GitHub tags form the basis for releases, so installing from
+   a tag is the same as downloading and installing a `specific release
+   <https://github.com/hpcng/singularity/releases>`_. Tags are expected
+   to be relatively stable and well-tested.
 
-- **release branch**: A release branch represents the latest version
-  of a minor release with all the newest bug fixes and enhancements
-  (even those that have not yet made it into a point release).  For
-  instance, to install v3.2 with the latest bug fixes and enhancements
-  checkout ``release-3.2``.  Release branches may be less stable than
-  code in a tagged point release.
+-  **release branch**: A release branch represents the latest version of
+   a minor release with all the newest bug fixes and enhancements (even
+   those that have not yet made it into a point release). For instance,
+   to install v3.2 with the latest bug fixes and enhancements checkout
+   ``release-3.2``. Release branches may be less stable than code in a
+   tagged point release.
 
-- **master branch**: The ``master`` branch contains the latest,
-  bleeding edge version of {Singularity}. This is the default branch
-  when you clone the source code, so you don't have to check out any
-  new branches to install it. The ``master`` branch changes quickly
-  and may be unstable.
+-  **master branch**: The ``master`` branch contains the latest,
+   bleeding edge version of {Singularity}. This is the default branch
+   when you clone the source code, so you don't have to check out any
+   new branches to install it. The ``master`` branch changes quickly and
+   may be unstable.
 
 To ensure that the {Singularity} source code is downloaded to the
 appropriate directory use these commands.
 
-.. code-block:: none
+.. code::
 
-    $ git clone https://github.com/hpcng/singularity.git && \
-        cd singularity && \
-        git checkout v{InstallationVersion}
+   $ git clone https://github.com/hpcng/singularity.git && \
+       cd singularity && \
+       git checkout v{InstallationVersion}
 
 Compile Singularity
-===================
+-------------------
 
-{Singularity} uses a custom build system called ``makeit``.  ``mconfig``
+{Singularity} uses a custom build system called ``makeit``. ``mconfig``
 is called to generate a ``Makefile`` and then ``make`` is used to
 compile and install.
 
@@ -433,105 +443,102 @@ To support the SIF image format, automated networking setup etc., and
 older Linux distributions without user namespace support, Singularity
 must be ``make install``ed as root or with ``sudo``, so it can install
 the ``libexec/singularity/bin/starter-setuid`` binary with root
-ownership and setuid permissions for privileged operations. If you
-need to install as a normal user, or do not want to use setuid
-functionality :ref:`see below <install-nonsetuid>`.
+ownership and setuid permissions for privileged operations. If you need
+to install as a normal user, or do not want to use setuid functionality
+:ref:`see below <install-nonsetuid>`.
 
-.. code-block:: none
+.. code::
 
-    $ ./mconfig && \
-        make -C ./builddir && \
-        sudo make -C ./builddir install
+   $ ./mconfig && \
+       make -C ./builddir && \
+       sudo make -C ./builddir install
 
 By default {Singularity} will be installed in the ``/usr/local``
 directory hierarchy. You can specify a custom directory with the
 ``--prefix`` option, to ``mconfig`` like so:
 
-.. code-block:: none
+.. code::
 
-    $ ./mconfig --prefix=/opt/singularity
+   $ ./mconfig --prefix=/opt/singularity
 
 This option can be useful if you want to install multiple versions of
 {Singularity}, install a personal version of {Singularity} on a shared
 system, or if you want to remove {Singularity} easily after installing
 it.
 
-For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
-are some of the most common options that you may need to use when
-building {Singularity} from source.
+For a full list of ``mconfig`` options, run ``mconfig --help``. Here are
+some of the most common options that you may need to use when building
+{Singularity} from source.
 
-- ``--sysconfdir``: Install read-only config files in sysconfdir.
-  This option is important if you need the ``singularity.conf`` file
-  or other configuration files in a custom location.
+-  ``--sysconfdir``: Install read-only config files in sysconfdir. This
+   option is important if you need the ``singularity.conf`` file or
+   other configuration files in a custom location.
 
-- ``--localstatedir``: Set the state directory where containers are
-  mounted. This is a particularly important option for administrators
-  installing {Singularity} on a shared file system.  The
-  ``--localstatedir`` should be set to a directory that is present on
-  each individual node.
+-  ``--localstatedir``: Set the state directory where containers are
+   mounted. This is a particularly important option for administrators
+   installing {Singularity} on a shared file system. The
+   ``--localstatedir`` should be set to a directory that is present on
+   each individual node.
 
-- ``-b``: Build {Singularity} in a given directory. By default this is
-  ``./builddir``.
+-  ``-b``: Build {Singularity} in a given directory. By default this is
+   ``./builddir``.
 
 .. _install-nonsetuid:
 
-
 Unprivileged (non-setuid) Installation
-======================================
+--------------------------------------
 
-If you need to install {Singularity} as a non-root user, or do not
-wish to allow the use of a setuid root binary, you can configure
+If you need to install {Singularity} as a non-root user, or do not wish
+to allow the use of a setuid root binary, you can configure
 {Singularity} with the ``--without-suid`` option to mconfig:
 
-.. code-block:: none
+.. code::
 
-    $ ./mconfig --without-suid --prefix=/home/dave/singularity && \
-        make -C ./builddir && \
-        make -C ./builddir install
+   $ ./mconfig --without-suid --prefix=/home/dave/singularity && \
+       make -C ./builddir && \
+       make -C ./builddir install
 
 If you have already installed {Singularity} you can disable the setuid
 flow by setting the option ``allow setuid = no`` in
-``etc/singularity/singularity.conf`` within your installation
-directory.
+``etc/singularity/singularity.conf`` within your installation directory.
 
-When {Singularity} does not use setuid all container execution will
-use a user namespace. This requires support from your operating system
-kernel, and imposes some limitations on functionality. You should
-review the :ref:`requirements <userns-requirements>` and
-:ref:`limitations <userns-limitations>` in the :ref:`user namespace
-<userns>` section of this guide.
+When {Singularity} does not use setuid all container execution will use
+a user namespace. This requires support from your operating system
+kernel, and imposes some limitations on functionality. You should review
+the :ref:`requirements <userns-requirements>` and :ref:`limitations
+<userns-limitations>` in the :ref:`user namespace <userns>` section of
+this guide.
 
 Relocatable Installation
-========================
+------------------------
 
 Since {Singularity} 3.8, an unprivileged (non-setuid) installation is
-relocatable. As long as the structure inside the installation
-directory (``--prefix``) is maintained, it can be moved to a different
-location and {Singularity} will continue to run normally.
+relocatable. As long as the structure inside the installation directory
+(``--prefix``) is maintained, it can be moved to a different location
+and {Singularity} will continue to run normally.
 
 Relocation of a default setuid installation is not supported, as
 restricted location / ownership of configuration files is important to
 security.
 
 Source bash completion file
-===========================
+---------------------------
 
-To enjoy bash shell completion with {Singularity} commands and
-options, source the bash completion file:
+To enjoy bash shell completion with {Singularity} commands and options,
+source the bash completion file:
 
-.. code-block:: none
+.. code::
 
-    $ . /usr/local/etc/bash_completion.d/singularity
+   $ . /usr/local/etc/bash_completion.d/singularity
 
 Add this command to your `~/.bashrc` file so that bash completion
-continues to work in new shells.  (Adjust the path if you installed
+continues to work in new shells. (Adjust the path if you installed
 {Singularity} to a different location.)
 
 .. _install-rpm:
 
-------------------------
 Build and install an RPM
-------------------------
+========================
 
 If you use RHEL, CentOS or SUSE, building and installing a Singularity
 RPM allows your {Singularity} installation be more easily managed,
@@ -541,66 +548,63 @@ directly from the `release tarball
 
 .. note::
 
-    Be sure to download the correct asset from the `GitHub releases
-    page <https://github.com/hpcng/singularity/releases>`_.  It
-    should be named `singularity-<version>.tar.gz`.
+   Be sure to download the correct asset from the `GitHub releases page
+   <https://github.com/hpcng/singularity/releases>`_. It should be
+   named `singularity-<version>.tar.gz`.
 
 After installing the :ref:`dependencies <install-dependencies>` and
 installing :ref:`Go <install-go>` as detailed above, you are ready to
 download the tarball and build and install the RPM.
 
-.. code-block:: none
+.. code::
 
-    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-        wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-        rpmbuild -tb singularity-${VERSION}.tar.gz && \
-        sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-$VERSION-1.el7.x86_64.rpm && \
-        rm -rf ~/rpmbuild singularity-$VERSION*.tar.gz
+   $ export VERSION={InstallationVersion} && # adjust this as necessary \
+       wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+       rpmbuild -tb singularity-${VERSION}.tar.gz && \
+       sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-$VERSION-1.el7.x86_64.rpm && \
+       rm -rf ~/rpmbuild singularity-$VERSION*.tar.gz
 
 If you encounter a failed dependency error for golang but installed it
 from source, build with this command:
 
-.. code-block:: none
+.. code::
 
-    rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz
-
+   rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz
 
 Options to ``mconfig`` can be passed using the familiar syntax to
-``rpmbuild``.  For example, if you want to force the local state
+``rpmbuild``. For example, if you want to force the local state
 directory to ``/mnt`` (instead of the default ``/var``) you can do the
 following:
 
-.. code-block:: none
+.. code::
 
-    rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz
+   rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz
 
 .. note::
 
-     It is very important to set the local state directory to a
-     directory that physically exists on nodes within a cluster when
-     installing {Singularity} in an HPC environment with a shared file
-     system.
+   It is very important to set the local state directory to a directory
+   that physically exists on nodes within a cluster when installing
+   {Singularity} in an HPC environment with a shared file system.
 
 Build an RPM from Git source
-============================
+----------------------------
 
 Alternatively, to build an RPM from a branch of the Git repository you
 can clone the repository, directly ``make`` an rpm, and use it to
 install Singularity:
 
-.. code-block:: none
+.. code::
 
   $ ./mconfig && \
   make -C builddir rpm && \
   sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-{InstallationVersion}.el7.x86_64.rpm # or whatever version you built
 
+To build an rpm with an alternative install prefix set ``RPMPREFIX`` on
+the make step, for example:
 
-To build an rpm with an alternative install prefix set ``RPMPREFIX``
-on the make step, for example:
+.. code::
 
-.. code-block:: none
-
-  $ make -C builddir rpm RPMPREFIX=/usr/local
+   $ make -C builddir rpm RPMPREFIX=/usr/local
 
 For finer control of the rpmbuild process you may wish to use ``make
 dist`` to create a tarball that you can then build into an rpm with
@@ -608,84 +612,81 @@ dist`` to create a tarball that you can then build into an rpm with
 
 .. _remove-an-old-version:
 
----------------------
 Remove an old version
----------------------
+=====================
 
 In a standard installation of {Singularity} 3.0.1 and beyond (when
 building from source), the command ``sudo make install`` lists all the
 files as they are installed. You must remove all of these files and
 directories to completely remove {Singularity}.
 
-.. code-block:: none
+.. code::
 
-    $ sudo rm -rf \
-        /usr/local/libexec/singularity \
-        /usr/local/var/singularity \
-        /usr/local/etc/singularity \
-        /usr/local/bin/singularity \
-        /usr/local/bin/run-singularity \
-        /usr/local/etc/bash_completion.d/singularity
+   $ sudo rm -rf \
+       /usr/local/libexec/singularity \
+       /usr/local/var/singularity \
+       /usr/local/etc/singularity \
+       /usr/local/bin/singularity \
+       /usr/local/bin/run-singularity \
+       /usr/local/etc/bash_completion.d/singularity
 
-If you anticipate needing to remove {Singularity}, it might be easier
-to install it in a custom directory using the ``--prefix`` option to
-``mconfig``.  In that case {Singularity} can be uninstalled simply by
+If you anticipate needing to remove {Singularity}, it might be easier to
+install it in a custom directory using the ``--prefix`` option to
+``mconfig``. In that case {Singularity} can be uninstalled simply by
 deleting the parent directory. Or it may be useful to install
 {Singularity} :ref:`using a package manager <install-rpm>` so that it
 can be updated and/or uninstalled with ease in the future.
 
-------------------------------------------
 Testing & Checking the Build Configuration
-------------------------------------------
+==========================================
 
 After installation you can perform a basic test of Singularity
 functionality by executing a simple container from the Sylabs Cloud
 library:
 
-.. code-block:: none
+.. code::
 
-    $ singularity exec library://alpine cat /etc/alpine-release
-    3.9.2
-
+   $ singularity exec library://alpine cat /etc/alpine-release
+   3.9.2
 
 See the `user guide
-<\{userdocs\}>`__ for more
+<{userdocs}>`__ for more
 information about how to use {Singularity}.
 
 singularity buildcfg
-====================
+--------------------
 
-Running ``singularity buildcfg`` will show the build configuration of
-an installed version of {Singularity}, and lists the paths used by
+Running ``singularity buildcfg`` will show the build configuration of an
+installed version of {Singularity}, and lists the paths used by
 {Singularity}. Use ``singularity buildcfg`` to confirm paths are set
-correctly for your installation, and troubleshoot any 'not-found'
-errors at runtime.
+correctly for your installation, and troubleshoot any 'not-found' errors
+at runtime.
 
-.. code-block:: none
+.. code::
 
-    $ singularity buildcfg
-    PACKAGE_NAME=singularity
-    PACKAGE_VERSION={InstallationVersion}
-    BUILDDIR=/home/dtrudg/Sylabs/Git/singularity/builddir
-    PREFIX=/usr/local
-    EXECPREFIX=/usr/local
-    BINDIR=/usr/local/bin
-    SBINDIR=/usr/local/sbin
-    LIBEXECDIR=/usr/local/libexec
-    DATAROOTDIR=/usr/local/share
-    DATADIR=/usr/local/share
-    SYSCONFDIR=/usr/local/etc
-    SHAREDSTATEDIR=/usr/local/com
-    LOCALSTATEDIR=/usr/local/var
-    RUNSTATEDIR=/usr/local/var/run
-    INCLUDEDIR=/usr/local/include
-    DOCDIR=/usr/local/share/doc/singularity
-    INFODIR=/usr/local/share/info
-    LIBDIR=/usr/local/lib
-    LOCALEDIR=/usr/local/share/locale
-    MANDIR=/usr/local/share/man
-    SINGULARITY_CONFDIR=/usr/local/etc/singularity
-    SESSIONDIR=/usr/local/var/singularity/mnt/session
+   $ singularity buildcfg
+   PACKAGE_NAME=singularity
+   PACKAGE_VERSION={InstallationVersion}
+   BUILDDIR=/home/dtrudg/Sylabs/Git/singularity/builddir
+   PREFIX=/usr/local
+   EXECPREFIX=/usr/local
+   BINDIR=/usr/local/bin
+   SBINDIR=/usr/local/sbin
+   LIBEXECDIR=/usr/local/libexec
+   DATAROOTDIR=/usr/local/share
+   DATADIR=/usr/local/share
+   SYSCONFDIR=/usr/local/etc
+   SHAREDSTATEDIR=/usr/local/com
+   LOCALSTATEDIR=/usr/local/var
+   RUNSTATEDIR=/usr/local/var/run
+   INCLUDEDIR=/usr/local/include
+   DOCDIR=/usr/local/share/doc/singularity
+   INFODIR=/usr/local/share/info
+   LIBDIR=/usr/local/lib
+   LOCALEDIR=/usr/local/share/locale
+   MANDIR=/usr/local/share/man
+   SINGULARITY_CONFDIR=/usr/local/etc/singularity
+   SESSIONDIR=/usr/local/var/singularity/mnt/session
 
 Note that the ``LOCALSTATEDIR`` and ``SESSIONDIR`` should be on local,
 non-shared storage.
@@ -695,7 +696,7 @@ The list of files installed by a successful `setuid` installation of
 section <installed-files>`.
 
 Test Suite
-==========
+----------
 
 The {Singularity} codebase includes a test suite that is run during
 development using CI services.
@@ -703,138 +704,133 @@ development using CI services.
 If you would like to run the test suite locally you can run the test
 targets from the ``builddir`` directory in the source tree:
 
-  - ``make check`` runs source code linting and dependency checks
-  - ``make unit-test`` runs basic unit tests
-  - ``make integration-test`` runs integration tests
-  - ``make e2e-test`` runs end-to-end tests, which exercise a large
-    number of operations by calling the {Singularity} CLI with different
-    execution profiles.
+   -  ``make check`` runs source code linting and dependency checks
+
+   -  ``make unit-test`` runs basic unit tests
+
+   -  ``make integration-test`` runs integration tests
+
+   -  ``make e2e-test`` runs end-to-end tests, which exercise a large
+      number of operations by calling the {Singularity} CLI with
+      different execution profiles.
 
 .. note::
 
-    Running the full test suite requires a ``docker`` installation,
-    and ``nc`` in order to test docker and instance/networking
-    functionality.
+   Running the full test suite requires a ``docker`` installation, and
+   ``nc`` in order to test docker and instance/networking functionality.
 
-    {Singularity} must be installed in order to run the full test
-    suite, as it must run the CLI with setuid privilege for the
-    ``starter-suid`` binary.
+   {Singularity} must be installed in order to run the full test suite,
+   as it must run the CLI with setuid privilege for the ``starter-suid``
+   binary.
 
 .. warning::
 
-    ``sudo`` privilege is required to run the full tests, and you
-    should not run the tests on a production system. We recommend
-    running the tests in an isolated development or build environment.
+   ``sudo`` privilege is required to run the full tests, and you should
+   not run the tests on a production system. We recommend running the
+   tests in an isolated development or build environment.
 
-==============================
-Installation on Windows or Mac
-==============================
+********************************
+ Installation on Windows or Mac
+********************************
 
 Linux container runtimes like {Singularity} cannot run natively on
-Windows or Mac because of basic incompatibilities with the host
-kernel. (Contrary to a popular misconception, MacOS does not run on a
-Linux kernel. It runs on a kernel called Darwin originally forked from
-BSD.)
+Windows or Mac because of basic incompatibilities with the host kernel.
+(Contrary to a popular misconception, MacOS does not run on a Linux
+kernel. It runs on a kernel called Darwin originally forked from BSD.)
 
-For this reason, the {Singularity} community maintains a set of
-Vagrant Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one
-of `Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
+For this reason, the {Singularity} community maintains a set of Vagrant
+Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one of
+`Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
 source tools. The current versions can be found under the `sylabs
 <https://app.vagrantup.com/sylabs>`_ organization.
 
--------
 Windows
--------
+=======
 
 Install the following programs:
 
- -  `Git for Windows <https://git-for-windows.github.io/>`_
- -  `VirtualBox for Windows <https://www.virtualbox.org/wiki/Downloads>`_
- -  `Vagrant for Windows <https://www.vagrantup.com/downloads.html>`_
- -  `Vagrant Manager for Windows <http://vagrantmanager.com/downloads/>`_
+   -  `Git for Windows <https://git-for-windows.github.io/>`_
+   -  `VirtualBox for Windows
+      <https://www.virtualbox.org/wiki/Downloads>`_
+   -  `Vagrant for Windows <https://www.vagrantup.com/downloads.html>`_
+   -  `Vagrant Manager for Windows
+      <http://vagrantmanager.com/downloads/>`_
 
----
 Mac
----
+===
 
 Singularity is available via Vagrant (installable with `Homebrew
 <https://brew.sh>`_ or manually)
 
 To use Vagrant via Homebrew:
 
-.. code-block:: none
+.. code::
 
-    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    $ brew install --cask virtualbox vagrant vagrant-manager
+   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+   $ brew install --cask virtualbox vagrant vagrant-manager
 
--------------------------
 {Singularity} Vagrant Box
--------------------------
+=========================
 
 Run Git Bash (Windows) or open a terminal (Mac) and create and enter a
 directory to be used with your Vagrant VM.
 
-.. code-block:: none
+.. code::
 
-    $ mkdir vm-singularity && \
-        cd vm-singularity
+   $ mkdir vm-singularity && \
+       cd vm-singularity
 
 If you have already created and used this folder for another VM, you
 will need to destroy the VM and delete the Vagrantfile.
 
-.. code-block:: none
+.. code::
 
-    $ vagrant destroy && \
-        rm Vagrantfile
+   $ vagrant destroy && \
+       rm Vagrantfile
 
-Then issue the following commands to bring up the Virtual
-Machine. (Substitute a different value for the ``$VM`` variable if you
-like.)
+Then issue the following commands to bring up the Virtual Machine.
+(Substitute a different value for the ``$VM`` variable if you like.)
 
-.. code-block:: none
+.. code::
 
-    $ export VM=sylabs/singularity-3.8-ubuntu-bionic64 && \
-        vagrant init $VM && \
-        vagrant up && \
-        vagrant ssh
+   $ export VM=sylabs/singularity-3.8-ubuntu-bionic64 && \
+       vagrant init $VM && \
+       vagrant up && \
+       vagrant ssh
 
-You can check the installed version of {Singularity} with the
-following:
+You can check the installed version of {Singularity} with the following:
 
-.. code-block:: none
+.. code::
 
-    vagrant@vagrant:~$ singularity version
-    {InstallationVersion}
+   vagrant@vagrant:~$ singularity version
+   {InstallationVersion}
 
+Of course, you can also start with a plain OS Vagrant box as a base and
+then install {Singularity} using one of the above methods for Linux.
 
-Of course, you can also start with a plain OS Vagrant box as a base
-and then install {Singularity} using one of the above methods for
-Linux.
-
---------------------------
 {Singularity} Docker Image
---------------------------
+==========================
 
 It is possible to use a Dockerized Singularity, here is a sample
 ``compose.yaml`` (Singularity version 3.7.4) for use with Docker
 Compose:
 
-.. code-block:: none
+.. code::
 
-    services:
-      singularity:
-        image: quay.io/singularity/singularity:v3.7.4-slim
-        stdin_open: true
-        tty: true
-        privileged: true
-        volumes:
-          - .:/root
-        entrypoint: ["/bin/sh"]
+   services:
+     singularity:
+       image: quay.io/singularity/singularity:v3.7.4-slim
+       stdin_open: true
+       tty: true
+       privileged: true
+       volumes:
+         - .:/root
+       entrypoint: ["/bin/sh"]
 
 Singularity in Docker can have various disadvantages, but basic
-container operations will work.  Currently, the intended use case is
+container operations will work. Currently, the intended use case is
 continuous integration, meaning that you should be able to build a
-Singularity container using this Docker Compose file.  For more
+Singularity container using this Docker Compose file. For more
 information see `issue#5
 <https://github.com/sylabs/singularity-admindocs/issues/5#issuecomment-852307931>`_
 and the image's source `repo

--- a/license.rst
+++ b/license.rst
@@ -1,9 +1,8 @@
-=======
-License
-=======
+#########
+ License
+#########
 
 This documentation is subject to the following 3-clause BSD license:
 
 .. include:: LICENSE
    :literal:
-

--- a/replacements.py
+++ b/replacements.py
@@ -14,7 +14,7 @@ def variableReplace(app, docname, source):
 variable_replacements = {
     # This is used in install instructions, so should be a full version
     "{InstallationVersion}" : "3.8.5",
-    "\{userdocs\}" : "https://singularity.hpcng.org/user-docs/3.8",
+    "{userdocs}" : "https://singularity.hpcng.org/user-docs/3.8",
     # The versions in the published guide URLs are for major.minor only
     "{adminversion}": "3.8",
     "{userversion}": "3.8",

--- a/security.rst
+++ b/security.rst
@@ -1,88 +1,118 @@
 .. _security:
 
-************************************
-Security in {Singularity} Containers
-************************************
+######################################
+ Security in {Singularity} Containers
+######################################
 
-Containers are all the rage today for many good reasons. They are lightweight, easy to spin-up and require reduced IT management resources as compared to hardware VM environments. More importantly, container technology facilitates advanced research computing by granting the ability to package software in highly portable and reproducible environments encapsulating all dependencies, including the operating system. But there are still some challenges to container security.
+Containers are all the rage today for many good reasons. They are
+lightweight, easy to spin-up and require reduced IT management resources
+as compared to hardware VM environments. More importantly, container
+technology facilitates advanced research computing by granting the
+ability to package software in highly portable and reproducible
+environments encapsulating all dependencies, including the operating
+system. But there are still some challenges to container security.
 
-Singularity, which is a container paradigm created by necessity for scientific and application driven workloads, addresses some
-core missions of containers : Mobility of Compute, Reproducibility, HPC support, and **Security**. This document intends to inform
-admins of different security features supported by {Singularity}.
+Singularity, which is a container paradigm created by necessity for
+scientific and application driven workloads, addresses some core
+missions of containers : Mobility of Compute, Reproducibility, HPC
+support, and **Security**. This document intends to inform admins of
+different security features supported by {Singularity}.
 
-{Singularity} Runtime
-#####################
+***********************
+ {Singularity} Runtime
+***********************
 
-The {Singularity} runtime enforces a unique security model that makes it appropriate for *untrusted users* to run *untrusted containers*
-safely on multi-tenant resources. Because the {Singularity} runtime dynamically writes UID and GID information to the appropriate files
-within the container, the user remains the same *inside* and *outside* the container, i.e., if you're an unprivileged
-user while entering the container, you'll remain an unprivileged user inside the container. A privilege separation model is in place
-to prevent users from escalating privileges once they are inside of a container. The container file system is mounted using the
-``nosuid`` option, and processes are spawned with the ``PR_NO_NEW_PRIVS`` flag. Taken together, this approach provides a secure way
-for users to run containers and greatly simplifies things like reading and writing data to the host system with appropriate
+The {Singularity} runtime enforces a unique security model that makes it
+appropriate for *untrusted users* to run *untrusted containers* safely
+on multi-tenant resources. Because the {Singularity} runtime dynamically
+writes UID and GID information to the appropriate files within the
+container, the user remains the same *inside* and *outside* the
+container, i.e., if you're an unprivileged user while entering the
+container, you'll remain an unprivileged user inside the container. A
+privilege separation model is in place to prevent users from escalating
+privileges once they are inside of a container. The container file
+system is mounted using the ``nosuid`` option, and processes are spawned
+with the ``PR_NO_NEW_PRIVS`` flag. Taken together, this approach
+provides a secure way for users to run containers and greatly simplifies
+things like reading and writing data to the host system with appropriate
 ownership.
 
-It is also important to note that the philosophy of {Singularity} is *Integration* over *Isolation*. Most container runtimes strive
-to isolate your container from the host system and other containers as much as possible. {Singularity}, on the
-other hand, assumes that the user’s primary goals are portability, reproducibility, and ease of use and that isolation is often a
-tertiary concern. Therefore, {Singularity} only isolates the mount namespace by default, and will also bind mount several host
-directories such as ``$HOME`` and ``/tmp`` into the container at runtime. If needed, additional levels of isolation can be achieved
-by passing options causing {Singularity} to enter any or all of the other kernel namespaces and to prevent automatic bind mounting.
-These measures allow users to interact with the host system from within the container in sensible ways.
+It is also important to note that the philosophy of {Singularity} is
+*Integration* over *Isolation*. Most container runtimes strive to
+isolate your container from the host system and other containers as much
+as possible. {Singularity}, on the other hand, assumes that the user’s
+primary goals are portability, reproducibility, and ease of use and that
+isolation is often a tertiary concern. Therefore, {Singularity} only
+isolates the mount namespace by default, and will also bind mount
+several host directories such as ``$HOME`` and ``/tmp`` into the
+container at runtime. If needed, additional levels of isolation can be
+achieved by passing options causing {Singularity} to enter any or all of
+the other kernel namespaces and to prevent automatic bind mounting.
+These measures allow users to interact with the host system from within
+the container in sensible ways.
 
-Singularity Image Format (SIF)
-##############################
+********************************
+ Singularity Image Format (SIF)
+********************************
 
-The Singularity community addresses container security as a continuous process. It attempts to provide container integrity throughout the distribution
-pipeline.. i.e., at rest, in transit and while running. Hence, the SIF has been designed to achieve these goals.
+Sylabs addresses container security as a continuous process. It attempts
+to provide container integrity throughout the distribution pipeline..
+i.e., at rest, in transit and while running. Hence, the SIF has been
+designed to achieve these goals.
 
-A SIF file is an immutable container runtime image. It is a physical representation of the container environment itself. An
-important component of SIF that elicits security feature is the ability to cryptographically sign a container, creating a signature
-block within the SIF file which can guarantee immutability and provide accountability as to who signed it. {Singularity} follows the
-`OpenPGP <https://www.openpgp.org/>`_ standard to create and manage these keys. After building an image within {Singularity}, users can
-``singularity sign`` the container and push it to the Library along with its public PGP key(Stored in :ref:`Keystore <keystore>`) which
-later can be verified (``singularity verify``) while pulling or downloading the image. This feature in particular
-protects collaboration within and between systems and teams.
+A SIF file is an immutable container runtime image. It is a physical
+representation of the container environment itself. An important
+component of SIF that elicits security feature is the ability to
+cryptographically sign a container, creating a signature block within
+the SIF file which can guarantee immutability and provide accountability
+as to who signed it. {Singularity} follows the `OpenPGP
+<https://www.openpgp.org/>`_ standard to create and manage these keys.
+After building an image within {Singularity}, users can ``singularity
+sign`` the container and push it to the Library along with its public
+PGP key(Stored in :ref:`Keystore <keystore>`) which later can be
+verified (``singularity verify``) while pulling or downloading the
+image. This feature in particular protects collaboration within and
+between systems and teams.
 
 SIF Encryption
-**************
+==============
 
 In {Singularity} 3.4 and above the container root filesystem that
 resides in the squashFS partition of a SIF can be encrypted, rendering
 it's contents inaccessible without a secret. Unlike other platforms,
 where encrypted layers must be assembled into an unencrypted runtime
 directory on disk, {Singularity} mounts the encrypted root file system
-directly from the SIF using Kernel dm-crypt/LUKS functionality, so
-that the content is not exposed on disk. {Singularity} containers
-provide a comparable level of security to LUKS2 full disk encryption
-commonly deployed on Linux server and desktop systems.
+directly from the SIF using Kernel dm-crypt/LUKS functionality, so that
+the content is not exposed on disk. {Singularity} containers provide a
+comparable level of security to LUKS2 full disk encryption commonly
+deployed on Linux server and desktop systems.
 
 As with all matters of security, a layered approach must be taken and
 the system as a whole considered. For example, it is possible that
 decrypted memory pages could be paged out the system swap file or
-device, which could result in decrypted information being stored at
-rest on physical media. Operating system level mitigations such as
-encrypted swap space may be required depending on the needs of your
-application.
+device, which could result in decrypted information being stored at rest
+on physical media. Operating system level mitigations such as encrypted
+swap space may be required depending on the needs of your application.
 
-Encryption and decryption of containers requires ``cryptsetup``
-version 2. The SIF root filesystem will be encrypted using the
-default LUKS cipher on the host. The current default cipher used by
-``cryptsetup`` for LUKS2 in mainstream Linux distributions is
-``aes-xts-plain64`` with a 256 bit key size. The default key
-derivation function for LUKS2 is ``argon2i``.
+Encryption and decryption of containers requires ``cryptsetup`` version
+2. The SIF root filesystem will be encrypted using the default LUKS
+cipher on the host. The current default cipher used by ``cryptsetup``
+for LUKS2 in mainstream Linux distributions is ``aes-xts-plain64`` with
+a 256 bit key size. The default key derivation function for LUKS2 is
+``argon2i``.
 
 {Singularity} currently supports 2 types of secrets for encrypted
 containers:
 
-  - *Passphrase*: a text passphrase is passed directly to
-    ``cryptsetup`` for LUKS encryption of the root fs.
-  - *Asymmetric RSA keypair*: a randomly generated 256-bit secret is
-    used to perform LUKS encryption of the rootfs.  This secret is
-    encrypted with a user-provided RSA public key, and the ciphertext
-    stored in the SIF file. At runtime the RSA private key must be
-    provided to decrypt the secret and allow decryption of the root
-    filesystem to use the container.
+   -  *Passphrase*: a text passphrase is passed directly to
+      ``cryptsetup`` for LUKS encryption of the root fs.
+
+   -  *Asymmetric RSA keypair*: a randomly generated 256-bit secret is
+      used to perform LUKS encryption of the rootfs. This secret is
+      encrypted with a user-provided RSA public key, and the ciphertext
+      stored in the SIF file. At runtime the RSA private key must be
+      provided to decrypt the secret and allow decryption of the root
+      filesystem to use the container.
 
 .. note::
 
@@ -90,100 +120,145 @@ containers:
    running ``cryptsetup --help``.
 
    ``cryptsetup`` sets a memory cost for the ``argon2i`` PBKDF based on
-   the RAM available in the system used for encryption, up to a
-   maximum of 1GiB. Encrypted containers created on systems with >2GiB
-   RAM may be unusable on systems with <1GiB of free RAM.
+   the RAM available in the system used for encryption, up to a maximum
+   of 1GiB. Encrypted containers created on systems with >2GiB RAM may
+   be unusable on systems with <1GiB of free RAM.
 
+**************************
+ Admin Configurable Files
+**************************
 
-
-Admin Configurable Files
-#########################
-
-{Singularity} Administrators have the ability to access various configuration files, that will let them set security
-restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <configfiles.html#ecl-toml>`_
-which allows blacklisting and whitelisting of containers. You can find all the configuration files and their parameters
-documented `here <configfiles.html>`__.
+{Singularity} Administrators have the ability to access various
+configuration files, that will let them set security restrictions, grant
+or revoke a user’s capabilities, manage resources and authorize
+containers etc. One such file interesting in this context is `ecl.toml
+<configfiles.html#ecl-toml>`_
+which allows blacklisting and whitelisting of containers. You can find
+all the configuration files and their parameters documented `here
+<configfiles.html>`__.
 
 cgroups support
-****************
+===============
 
-{Singularity} provides native support for ``cgroups``, allowing users to limit the resources their containers consume
-without the help of a separate program like a batch scheduling system. This feature helps in preventing DoS attacks where one
-container seizes control of all available system resources in order to stop other containers from operating properly.
-To utilize this feature, a user first creates a configuration file. An example configuration file is installed by default with
-{Singularity} to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration
-file and cgroups are configured accordingly. More about cgroups support `here <configfiles.html#cgroups-toml>`__.
+{Singularity} provides native support for ``cgroups``, allowing users to
+limit the resources their containers consume without the help of a
+separate program like a batch scheduling system. This feature helps in
+preventing DoS attacks where one container seizes control of all
+available system resources in order to stop other containers from
+operating properly. To utilize this feature, a user first creates a
+configuration file. An example configuration file is installed by
+default with {Singularity} to provide a guide. At runtime, the
+``--apply-cgroups`` option is used to specify the location of the
+configuration file and cgroups are configured accordingly. More about
+cgroups support `here
+<configfiles.html#cgroups-toml>`__.
 
-Applying cgroups resource limits on systems using the v2 unified hierarchy is supported under {Singularity} v3.9 and above.
+Applying cgroups resource limits on systems using the v2 unified
+hierarchy is supported under {Singularity} v3.9 and above.
 
 ``--security`` options
-***********************
+======================
 
-{Singularity} supports a number of methods for specifying the security scope and context when running {Singularity} containers.
-Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine
-grained control of security. Details about them are documented `here <\{userdocs\}/security_options.html>`__.
+{Singularity} supports a number of methods for specifying the security
+scope and context when running {Singularity} containers. Additionally,
+it supports new flags that can be passed to the action commands;
+``shell``, ``exec``, and ``run`` allowing fine grained control of
+security. Details about them are documented `here
+<{userdocs}/security_options.html>`__.
 
-Security in SCS
-###############
+*****************
+ Security in SCS
+*****************
 
-`Singularity Container Services (SCS) <https://cloud.sylabs.io>` consist of a Remote Builder, a Container Library, and a
-Keystore. Taken together, the Singularity Container Services provide an end-to-end solution for packaging and distributing
-applications in secure and trusted containers.
+`Singularity Container Services (SCS) <https://cloud.sylabs.io>` consist
+of a Remote Builder, a Container Library, and a Keystore. Taken
+together, the Singularity Container Services provide an end-to-end
+solution for packaging and distributing applications in secure and
+trusted containers.
 
 Remote Builder
-**************
+==============
 
-As mentioned earlier, the {Singularity} runtime prevents executing code with root-level permissions on the host system. But building a
-container requires elevated privileges that most production environments do not grant to users. `The Remote Builder <https://cloud.sylabs.io/builder>`_
-solves this challenge by allowing unprivileged users a service that can be used to build containers targeting one or more CPU
-architectures. System administrators can use the system to monitor which users are building containers, and the contents of those
-containers. Starting with {Singularity} 3.0, the CLI has native integration with the Build Service from version 3.0 onwards. In
-addition, a web GUI interface to the Build Service also exists, which allows users to build containers using only a web browser.
+As mentioned earlier, the {Singularity} runtime prevents executing code
+with root-level permissions on the host system. But building a container
+requires elevated privileges that most production environments do not
+grant to users. `The Remote Builder <https://cloud.sylabs.io/builder>`_
+solves this challenge by allowing unprivileged users a service that can
+be used to build containers targeting one or more CPU architectures.
+System administrators can use the system to monitor which users are
+building containers, and the contents of those containers. Starting with
+{Singularity} 3.0, the CLI has native integration with the Build Service
+from version 3.0 onwards. In addition, a web GUI interface to the Build
+Service also exists, which allows users to build containers using only a
+web browser.
 
 .. note::
 
-    Please see the :ref:`Fakeroot feature <fakeroot>` which is a secure option for admins in multi-tenant HPC environments and
-    similar use cases where they might want to grant a user special privileges inside a container.
+   Please see the :ref:`Fakeroot feature <fakeroot>` which is a secure
+   option for admins in multi-tenant HPC environments and similar use
+   cases where they might want to grant a user special privileges inside
+   a container.
 
 Container Library
-*****************
+=================
 
-The `Container Library <https://cloud.sylabs.io/library>`_ enables users to store and share {Singularity} container images based on
-the Singularity Image Format (SIF). A web front-end allows users to create new projects within the Container Library, edit
-documentation associated with container images, and discover container images published by their peers.
+The `Container Library <https://cloud.sylabs.io/library>`_ enables users
+to store and share {Singularity} container images based on the
+Singularity Image Format (SIF). A web front-end allows users to create
+new projects within the Container Library, edit documentation associated
+with container images, and discover container images published by their
+peers.
 
 .. _keystore:
 
 Key Store
-*********
+=========
 
-The `Key Store <https://cloud.sylabs.io/keystore>`_ is a key management system offered by Sylabs that utilizes `OpenPGP implementation <https://gnupg.org/>`_ to facilitate sharing and maintaining of PGP public keys used to sign and verify {Singularity} container images. This service is based on the OpenPGP HTTP Keyserver Protocol (HKP), with several enhancements:
+The `Key Store <https://cloud.sylabs.io/keystore>`_ is a key management
+system offered by Sylabs that utilizes `OpenPGP implementation
+<https://gnupg.org/>`_ to facilitate sharing and maintaining of PGP
+public keys used to sign and verify {Singularity} container images. This
+service is based on the OpenPGP HTTP Keyserver Protocol (HKP), with
+several enhancements:
 
-- The Service requires connections to be secured with Transport Layer Security (TLS).
-- The Service implements token-based authentication, allowing only authenticated users to add or modify PGP keys.
-- A web front-end allows users to view and search for PGP keys using a web browser.
-
+-  The Service requires connections to be secured with Transport Layer
+   Security (TLS).
+-  The Service implements token-based authentication, allowing only
+   authenticated users to add or modify PGP keys.
+-  A web front-end allows users to view and search for PGP keys using a
+   web browser.
 
 Security Considerations of Cloud Services:
-******************************************
+==========================================
 
-1. Communications between users, the auth service and the above-mentioned services are secured via TLS.
+#. Communications between users, the auth service and the
+   above-mentioned services are secured via TLS.
 
-2. The services support authentication of users via authentication tokens.
+#. The services support authentication of users via authentication
+   tokens.
 
-3. There is no implicit trust relationship between Auth and each of these services. Rather, each request between the services is authenticated using the authentication token supplied by the user in the associated request.
+#. There is no implicit trust relationship between Auth and each of
+   these services. Rather, each request between the services is
+   authenticated using the authentication token supplied by the user in
+   the associated request.
 
-4. The services support MongoDB authentication as well as TLS/SSL.
+#. The services support MongoDB authentication as well as TLS/SSL.
 
 .. note::
 
-   SingularityPRO is a professionally curated and licensed version of Singularity that provides added security, stability, and
-   support beyond that offered by the open source project. Subscribers receive advanced access to security patches through regular
-   updates so, when a CVE is announced publicly PRO subscribers are already using patched software.
+   SingularityPRO is a professionally curated and licensed version of
+   Singularity that provides added security, stability, and support
+   beyond that offered by the open source project. Subscribers receive
+   advanced access to security patches through regular updates so, when
+   a CVE is announced publicly PRO subscribers are already using patched
+   software.
 
-
-Security is not a check box that one can tick and forget.  It’s an ongoing process that begins with software architecture, and
-continues all the way through to ongoing security practices.  In addition to ensuring that containers are run without elevated
-privileges where appropriate, and that containers are produced by trusted sources, users must monitor their containers for newly
-discovered vulnerabilities and update when necessary just as they would with any other software. The Singularity community is constantly probing to
-find and patch vulnerabilities within {Singularity}, and will continue to do so.
+Security is not a check box that one can tick and forget. It’s an
+ongoing process that begins with software architecture, and continues
+all the way through to ongoing security practices. In addition to
+ensuring that containers are run without elevated privileges where
+appropriate, and that containers are produced by trusted sources, users
+must monitor their containers for newly discovered vulnerabilities and
+update when necessary just as they would with any other software. The Singularity community
+is constantly probing to find and patch vulnerabilities within
+{Singularity}, and will continue to do so.

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -1,35 +1,33 @@
 .. _userns:
 
-==========================
-User Namespaces & Fakeroot
-==========================
+############################
+ User Namespaces & Fakeroot
+############################
 
 User namespaces are an isolation feature that allow processes to run
-with different user identifiers and/or privileges inside that
-namespace than are permitted outside. A user may have a ``uid`` of
-``1001`` on a system outside of a user namespace, but run programs
-with a different ``uid`` with different privileges inside the
-namespace.
+with different user identifiers and/or privileges inside that namespace
+than are permitted outside. A user may have a ``uid`` of ``1001`` on a
+system outside of a user namespace, but run programs with a different
+``uid`` with different privileges inside the namespace.
 
-User namespaces are used with containers to make it possible to setup
-a container without privileged operations, and so that a normal user
-can act as root inside a container to perform administrative tasks,
-without being root on the host outside.
-
+User namespaces are used with containers to make it possible to setup a
+container without privileged operations, and so that a normal user can
+act as root inside a container to perform administrative tasks, without
+being root on the host outside.
 
 {Singularity} uses user namespaces in 3 situations:
 
- - When the ``setuid`` workflow is disabled or {Singularity} was
-   installed without root.
- - When a container is run with the ``--userns`` option.
- - When ``--fakeroot`` is used to impersonate a root user when
-   building or running a container.
+   -  When the ``setuid`` workflow is disabled or {Singularity} was
+      installed without root.
+   -  When a container is run with the ``--userns`` option.
+   -  When ``--fakeroot`` is used to impersonate a root user when
+      building or running a container.
 
 .. _userns-requirements:
 
----------------------------
-User Namespace Requirements
----------------------------
+*****************************
+ User Namespace Requirements
+*****************************
 
 To allow unprivileged creation of user namespaces a kernel >=3.8 is
 required, with >=3.18 being recommended due to security fixes for user
@@ -37,63 +35,67 @@ namespaces (3.18 also adds OverlayFS support which is used by
 Singularity).
 
 Additionally, some Linux distributions require that unprivileged user
-namespace creation is enabled using a ``sysctl`` or kernel command
-line parameter. Please consult your distribution documentation or
-vendor to confirm the steps necessary to 'enable unprivileged user
-namespace creation'.
+namespace creation is enabled using a ``sysctl`` or kernel command line
+parameter. Please consult your distribution documentation or vendor to
+confirm the steps necessary to 'enable unprivileged user namespace
+creation'.
 
 Debian
 ======
 
-.. code-block:: none
+.. code::
 
-  sudo sh -c 'echo kernel.unprivileged_userns_clone=1 \
-      >/etc/sysctl.d/90-unprivileged_userns.conf'
-  sudo sysctl -p /etc/sysctl.d /etc/sysctl.d/90-unprivileged_userns.conf
+   sudo sh -c 'echo kernel.unprivileged_userns_clone=1 \
+       >/etc/sysctl.d/90-unprivileged_userns.conf'
+   sudo sysctl -p /etc/sysctl.d /etc/sysctl.d/90-unprivileged_userns.conf
 
 RHEL/CentOS 7
 =============
 
 From 7.4, kernel support is included but must be enabled with:
 
-.. code-block:: none
+.. code::
 
-  sudo sh -c 'echo user.max_user_namespaces=15000 \
-      >/etc/sysctl.d/90-max_net_namespaces.conf'
-  sudo sysctl -p /etc/sysctl.d /etc/sysctl.d/90-max_net_namespaces.conf
+   sudo sh -c 'echo user.max_user_namespaces=15000 \
+       >/etc/sysctl.d/90-max_net_namespaces.conf'
+   sudo sysctl -p /etc/sysctl.d /etc/sysctl.d/90-max_net_namespaces.conf
 
 .. _userns-limitations:
 
---------------------------
-Unprivileged Installations
---------------------------
+****************************
+ Unprivileged Installations
+****************************
 
 As detailed in the :ref:`non-setuid installation <install-nonsetuid>`
 section, {Singularity} can be compiled or configured with the ``allow
 setuid = no`` option in ``singularity.conf`` to not perform privileged
 operations using the ``starter-setuid`` binary.
 
-When {Singularity} does not use ``setuid`` all container execution
-will use a user namespace. In this mode of operation, some features
-are not available, and there are impacts to the security/integrity
-guarantees when running SIF container images:
+When {Singularity} does not use ``setuid`` all container execution will
+use a user namespace. In this mode of operation, some features are not
+available, and there are impacts to the security/integrity guarantees
+when running SIF container images:
 
- - All containers must be run from sandbox directories. SIF images are
-   extracted to a sandbox directory on the fly, preventing
-   verification at runtime, and potentially allowing external
-   modification of the container at runtime.
- - Filesystem image, and SIF-embedded persistent overlays cannot be
-   used.
- - Encrypted containers cannot be used. {Singularity} mounts encrypted
-   containers directly through the kernel, so that encrypted content
-   is not extracted to disk. This requires the setuid workflow.
- - Fakeroot functionality will rely on external setuid root
-   ``newuidmap`` and ``newgidmap`` binaries which may be provided by
-   the distribution.
+   -  All containers must be run from sandbox directories. SIF images
+      are extracted to a sandbox directory on the fly, preventing
+      verification at runtime, and potentially allowing external
+      modification of the container at runtime.
 
----------------
---userns option
----------------
+   -  Filesystem image, and SIF-embedded persistent overlays cannot be
+      used.
+
+   -  Encrypted containers cannot be used. {Singularity} mounts
+      encrypted containers directly through the kernel, so that
+      encrypted content is not extracted to disk. This requires the
+      setuid workflow.
+
+   -  Fakeroot functionality will rely on external setuid root
+      ``newuidmap`` and ``newgidmap`` binaries which may be provided by
+      the distribution.
+
+*****************
+ --userns option
+*****************
 
 The ``--userns`` option to `singularity run/exec/shell` will start a
 container using a user namespace, avoiding the setuid privileged
@@ -104,21 +106,21 @@ The same limitations apply as in an unprivileged installation.
 
 .. _fakeroot:
 
-----------------
-Fakeroot feature
-----------------
+******************
+ Fakeroot feature
+******************
 
-Fakeroot (or commonly referred as rootless mode) allows an
-unprivileged user to run a container as a **"fake root"** user by
-leveraging user namespaces with `user namespace UID/GID mapping
+Fakeroot (or commonly referred as rootless mode) allows an unprivileged
+user to run a container as a **"fake root"** user by leveraging user
+namespaces with `user namespace UID/GID mapping
 <http://man7.org/linux/man-pages/man7/user_namespaces.7.html>`_.
 
 User namespace UID/GID mapping allows a user to act as a different
-UID/GID in the container than they are on the host. A user can access
-a configured range of UIDs/GIDs in the container, which map back to
-(generally) unprivileged user UIDs/GIDs on the host. This allows a
-user to be ``root (uid 0)`` in a container, install packages etc., but
-have no privilege on the host.
+UID/GID in the container than they are on the host. A user can access a
+configured range of UIDs/GIDs in the container, which map back to
+(generally) unprivileged user UIDs/GIDs on the host. This allows a user
+to be ``root (uid 0)`` in a container, install packages etc., but have
+no privilege on the host.
 
 Requirements
 ============
@@ -128,9 +130,8 @@ In addition to user namespace support, {Singularity} must manipulate
 default this happens transparently in the setuid workflow. With
 unprivileged installations of {Singularity} or where ``allow setuid =
 no`` is set in ``singularity.conf``, {Singularity} attempts to use
-external setuid binaries ``newuidmap`` and ``newgidmap``, so you need
-to install those binaries on your system.
-
+external setuid binaries ``newuidmap`` and ``newgidmap``, so you need to
+install those binaries on your system.
 
 Basics
 ======
@@ -138,55 +139,54 @@ Basics
 Fakeroot relies on ``/etc/subuid`` and ``/etc/subgid`` files to find
 configured mappings from real user and group IDs, to a range of
 otherwise vacant IDs for each user on the host system that can be
-remapped in the usernamespace. A user must have an entry in these
-system configuration files to use the fakeroot feature. {Singularity}
-provides a :ref:`config fakeroot <config-fakeroot>` command to assist
-in managing these files, but it is important to understand how they
-work.
+remapped in the usernamespace. A user must have an entry in these system
+configuration files to use the fakeroot feature. {Singularity} provides
+a :ref:`config fakeroot <config-fakeroot>` command to assist in managing
+these files, but it is important to understand how they work.
 
 For user ``foo`` an entry in ``/etc/subuid`` might be:
 
-.. code-block:: none
+.. code::
 
-  foo:100000:65536
+   foo:100000:65536
 
-where ``foo`` is the username, ``100000`` is the start of the UID
-range that can be used by ``foo`` in a user namespace uid mapping, and
+where ``foo`` is the username, ``100000`` is the start of the UID range
+that can be used by ``foo`` in a user namespace uid mapping, and
 ``65536`` number of UIDs available for mapping.
 
 Same for ``/etc/subgid``:
 
-.. code-block:: none
+.. code::
 
-  foo:100000:65536
+   foo:100000:65536
 
 .. note::
 
-  Some distributions add users to these files on installation, or when
-  ``useradd``, ``adduser``, etc. utilities are used to manage local
-  users.
+   Some distributions add users to these files on installation, or when
+   ``useradd``, ``adduser``, etc. utilities are used to manage local
+   users.
 
-  The glibc nss name service switch mechanism does not currently
-  support managing ``subuid`` and ``subgid`` mappings with external
-  directory services such as LDAP. You must manage or provision
-  mapping files direct to systems where fakeroot will be used.
+   The glibc nss name service switch mechanism does not currently
+   support managing ``subuid`` and ``subgid`` mappings with external
+   directory services such as LDAP. You must manage or provision mapping
+   files direct to systems where fakeroot will be used.
 
 .. warning::
 
-  {Singularity} requires that a range of at least ``65536`` IDs is
-  used for each mapping. Larger ranges may be defined without error.
+   {Singularity} requires that a range of at least ``65536`` IDs is used
+   for each mapping. Larger ranges may be defined without error.
 
-  It is also important to ensure that the subuid and subgid ranges
-  defined in these files don't overlap with eachother, or any real
-  UIDs and GIDs on the host system.
+   It is also important to ensure that the subuid and subgid ranges
+   defined in these files don't overlap with eachother, or any real UIDs
+   and GIDs on the host system.
 
 So if you want to add another user ``bar``, ``/etc/subuid`` and
 ``/etc/subgid`` will look like:
 
-.. code-block:: none
+.. code::
 
-  foo:100000:65536
-  bar:165536:65536
+   foo:100000:65536
+   bar:165536:65536
 
 Resulting in the following allocation:
 
@@ -198,13 +198,12 @@ Resulting in the following allocation:
 | bar  | 1001     | 165536 to 231071     |
 +------+----------+----------------------+
 
-Inside a user namespace / container, ``foo`` and ``bar`` can now act
-as any UID/GID between 0 and 65536, but these UIDs are confined to the
+Inside a user namespace / container, ``foo`` and ``bar`` can now act as
+any UID/GID between 0 and 65536, but these UIDs are confined to the
 container. For ``foo`` UID 0 in the container will map to the host
 ``foo`` UID ``1000`` and ``1 to 65536`` will map to ``100000-165535``
-outside of the container etc. This impacts the ownership of files,
-which will have different IDs inside and outside of the container.
-
+outside of the container etc. This impacts the ownership of files, which
+will have different IDs inside and outside of the container.
 
 .. note::
 
@@ -212,10 +211,10 @@ which will have different IDs inside and outside of the container.
    to specify users by UID rather than username in the ``/etc/subuid``
    and ``/etc/subgid`` files. The man page for ``subuid`` advises:
 
-     When large number of entries (10000-100000 or more) are defined in
-     /etc/subuid, parsing performance penalty will become noticeable. In
-     this case it is recommended to use UIDs instead of login
-     names. Benchmarks have shown speed-ups up to 20x.
+      When large number of entries (10000-100000 or more) are defined in
+      /etc/subuid, parsing performance penalty will become noticeable.
+      In this case it is recommended to use UIDs instead of login names.
+      Benchmarks have shown speed-ups up to 20x.
 
 Filesystem considerations
 =========================
@@ -238,83 +237,78 @@ directories and files created with a subuid, as they do not match with
 the user's UID on the host. The user can remove these files by using a
 container shell running with fakeroot.
 
-
 Network configuration
 =====================
 
-With fakeroot, users can request a container network named
-``fakeroot``, other networks are restricted and can only be used by
-the real host root user. By default the ``fakeroot`` network is
-configured to use a network veth pair.
+With fakeroot, users can request a container network named ``fakeroot``,
+other networks are restricted and can only be used by the real host root
+user. By default the ``fakeroot`` network is configured to use a network
+veth pair.
 
 .. warning::
 
    Do not change the ``fakeroot`` network type in
-   ``etc/singularity/network/40_fakeroot.conflist`` without
-   considering the security implications.
+   ``etc/singularity/network/40_fakeroot.conflist`` without considering
+   the security implications.
 
 .. note::
 
-  Unprivileged installations of {Singularity} cannot use ``fakeroot``
-  network as it requires privilege during container creation to setup
-  the network.
+   Unprivileged installations of {Singularity} cannot use ``fakeroot``
+   network as it requires privilege during container creation to setup
+   the network.
 
 .. _config-fakeroot:
 
 Configuration with ``config fakeroot``
 ======================================
 
-{Singularity} 3.5 and above provides a ``config fakeroot`` command
-that can be used by a root user to administer local system
-``/etc/subuid`` and ``/etc/subgid`` files in a simple manner. This
-allows users to be granted the ability to use Singularity's fakeroot
-functionality without editing the files manually. The ``config
-fakeroot`` command will automatically ensure that generated
-subuid/subgid ranges are an approriate size, and do not overlap.
+{Singularity} 3.5 and above provides a ``config fakeroot`` command that
+can be used by a root user to administer local system ``/etc/subuid``
+and ``/etc/subgid`` files in a simple manner. This allows users to be
+granted the ability to use Singularity's fakeroot functionality without
+editing the files manually. The ``config fakeroot`` command will
+automatically ensure that generated subuid/subgid ranges are an
+approriate size, and do not overlap.
 
 ``config fakeroot`` must be run as the ``root`` user, or via ``sudo
-singularity config fakeroot`` as the ``/etc/subuid`` and
-``/etc/subgid`` files form part of the system configuration, and are
-security sensitive. You may ``--add`` or ``--remove`` user
-subuid/subgid mappings. You can also ``--enable`` or ``--disable``
-existing mappings.
-
+singularity config fakeroot`` as the ``/etc/subuid`` and ``/etc/subgid``
+files form part of the system configuration, and are security sensitive.
+You may ``--add`` or ``--remove`` user subuid/subgid mappings. You can
+also ``--enable`` or ``--disable`` existing mappings.
 
 .. note::
 
-  If you deploy {Singularity} to a cluster you will need to make
-  arrangements to synchronize ``/etc/subuid`` and ``/etc/subgid``
-  mapping files to all nodes.
+   If you deploy {Singularity} to a cluster you will need to make
+   arrangements to synchronize ``/etc/subuid`` and ``/etc/subgid``
+   mapping files to all nodes.
 
-  At this time, the glibc name service switch functionality does not
-  support subuid or subgid mappings, so they cannot be definied in a
-  central directory such as LDAP.
-
+   At this time, the glibc name service switch functionality does not
+   support subuid or subgid mappings, so they cannot be definied in a
+   central directory such as LDAP.
 
 Adding a fakeroot mapping
---------------------------
+-------------------------
 
-Use the ``-a/--add <user>`` option to ``config fakeroot`` to create
-new mapping entries so that ``<user>`` can use the fakeroot feature of
+Use the ``-a/--add <user>`` option to ``config fakeroot`` to create new
+mapping entries so that ``<user>`` can use the fakeroot feature of
 Singularity:
 
- .. code-block:: none
+   .. code::
 
-  $ sudo singularity config fakeroot --add dave
+      $ sudo singularity config fakeroot --add dave
 
-  # Show generated `/etc/subuid`
-  $ cat /etc/subuid
-  1000:4294836224:65536
+      # Show generated `/etc/subuid`
+      $ cat /etc/subuid
+      1000:4294836224:65536
 
-  # Show generated `/etc/subgid`
-  $ cat /etc/subgid
-  1000:4294836224:65536
+      # Show generated `/etc/subgid`
+      $ cat /etc/subgid
+      1000:4294836224:65536
 
-
- The first subuid range will be set to the top of the 32-bit UID
- space. Subsequent subuid ranges for additional users will be created
- working down from this value. This minimizes the change of overlap
- with real UIDs on most systems.
+   The first subuid range will be set to the top of the 32-bit UID
+   space. Subsequent subuid ranges for additional users will be created
+   working down from this value. This minimizes the change of overlap
+   with real UIDs on most systems.
 
 .. note::
 
@@ -324,25 +318,23 @@ Singularity:
    mappings, and the command can be used to manipulate these by
    username.
 
-
 Deleting, disabling, enabling mappings
 --------------------------------------
 
 Use the ``-r/--remove <user>`` option to ``config fakeroot`` to
-completely remove mapping entries. The ``<user>`` will no longer be
-able to use the fakeroot feature of Singularity:
+completely remove mapping entries. The ``<user>`` will no longer be able
+to use the fakeroot feature of Singularity:
 
-.. code-block:: none
+.. code::
 
-  $ sudo singularity config fakeroot --remove dave
+   $ sudo singularity config fakeroot --remove dave
 
 .. warning::
 
    If a fakeroot mapping is removed, the subuid/subgid range may be
-   assigned to another user via ``--add``. Any remaining files from
-   the prior user that were created with this mapping will be
-   accessible to the new user via fakeroot.
-
+   assigned to another user via ``--add``. Any remaining files from the
+   prior user that were created with this mapping will be accessible to
+   the new user via fakeroot.
 
 The ``-d/--disable`` and ``-e/--enable`` options will comment and
 uncomment entries in the mapping files, to temporarily disable and
@@ -351,18 +343,18 @@ useful to disable fakeroot for a user, but ensure the subuid/subgid
 range assigned to them is reserved, and not re-assigned to a different
 user.
 
-.. code-block:: none
+.. code::
 
-  # Disable dave
-  $ sudo singularity config fakeroot --disable dave
+   # Disable dave
+   $ sudo singularity config fakeroot --disable dave
 
-  # Entry is commented
-  $ cat /etc/subuid
-  !1000:4294836224:65536
+   # Entry is commented
+   $ cat /etc/subuid
+   !1000:4294836224:65536
 
-  # Enable dave
-  $ sudo singularity config fakeroot --enable dave
+   # Enable dave
+   $ sudo singularity config fakeroot --enable dave
 
-  # Entry is active
-  $ cat /etc/subuid
-  1000:4294836224:65536
+   # Entry is active
+   $ cat /etc/subuid
+   1000:4294836224:65536


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-admindocs#29

The original PR description was:

> Found `rstfmt` which will fix more consistency issues than the simple wrapping / whitespace cleanup applied in sylabs/singularity-admindocs#28.
> 
> Fixes the heading markup to be consistent, following the Python doc
> conventions.
> 
> Fixes indentation to be consistent.
> 
> Also fix incorrect lexer names (none is not a lexer).
> 
> Edit - Noting that rstfmt marks itself as an experimental / unstable project, so it's not really appropriate to use it in CI, or require manual use of it in our contribution guidelines. It was suitable here to get us to consistency at a point in time.... in order to encourage maintaining that consistency in future contributions.